### PR TITLE
Fix DLSS for #230

### DIFF
--- a/Extensions/CameraExtensions.cs
+++ b/Extensions/CameraExtensions.cs
@@ -9,7 +9,9 @@ namespace EFT.Trainer.Extensions
 		public static Vector3 WorldPointToScreenPoint(this Camera camera, Vector3 worldPoint)
 		{
 			var screenPoint = camera.WorldToScreenPoint(worldPoint);
-			screenPoint.y = Screen.height - screenPoint.y;
+			float scale = (float)Screen.height / (float)camera.scaledPixelHeight;
+			screenPoint.y = Screen.height - (screenPoint.y * scale);
+			screenPoint.x = screenPoint.x * scale;
 			return screenPoint;
 		}
 


### PR DESCRIPTION
Fixes DLSS by calculating a scale value using Screen.height divided by camera.scaledPixelHeight. Not sure if this is the best method to accomplish this as I am kind of new to C# but local testing shows it works and places all markers in the right spot at all DLSS quality settings. Additionally works with supersampling and downsampling settings.