### PR TITLE
Added option to display corpse containers

### DIFF
--- a/Features/LootItems.cs
+++ b/Features/LootItems.cs
@@ -28,6 +28,9 @@ namespace EFT.Trainer.Features
 
 		[ConfigurationProperty]
 		public bool SearchInsideCorpses { get; set; } = true;
+		
+		[ConfigurationProperty]
+		public bool ShowCorpses {  get; set; } = true;
 
 		[ConfigurationProperty]
 		public bool ShowPrices { get; set; } = true;
@@ -136,6 +139,11 @@ namespace EFT.Trainer.Features
 
 				if (lootItem is Corpse corpse)
 				{
+					if (ShowCorpses)
+					{
+						AddCorpse(lootItem.Item, records, camera, position);
+						continue;
+					}
 					if (SearchInsideCorpses)
 						FindItemsInRootItem(records, camera, corpse.ItemOwner?.RootItem, position);
 
@@ -184,6 +192,17 @@ namespace EFT.Trainer.Features
 				return true;
 
 			return trackedRarity.Value == itemRarity;
+		}
+		
+		private void AddCorpse(Item item, List<PointOfInterest> records, Camera camera, Vector3 position, string? owner = null)
+		{
+			records.Add(new PointOfInterest
+			{
+				Name = "Corpse",
+				Position = position,
+				ScreenPosition = camera.WorldPointToScreenPoint(position),
+				Color = Color
+			});
 		}
 	}
 }


### PR DESCRIPTION
Added a toggle for showing corpse containers under the loot option. Might not be the best way to accomplish this but it is functional. Occasionally depending on how the body ragdolls the marker can be some distance away from where the container is. Hardcoded name to "Corpse" as the container name is "Default Inventory". Code style is not great as I am still bad at C#. Tested on SPT 3.5.0 and 3.4.1 Fixes #257.