### PR TITLE
Load the trainer as SptAki/BepInEx module instead of using NLog.

### DIFF
--- a/BepInExPlugin/AkiEftTrainerPlugin.cs
+++ b/BepInExPlugin/AkiEftTrainerPlugin.cs
@@ -1,0 +1,21 @@
+﻿using BepInEx;
+using EFT.Trainer;
+using JetBrains.Annotations;
+
+[BepInPlugin("com.spt-aki.efttrainer", "AKI.EftTrainer", "1.0.0")]
+[UsedImplicitly]
+public class AkiDebuggingPlugin : BaseUnityPlugin
+{
+	public static bool Loaded = false;
+
+	[UsedImplicitly]
+	public void Awake()
+	{
+		if (Loaded) 
+			return;
+
+		Loader.Load();
+		Loaded = true;
+	}
+
+}

--- a/BepInExPlugin/BepInExPlugin.csproj
+++ b/BepInExPlugin/BepInExPlugin.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>aki-efttrainer</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <LangVersion>9.0</LangVersion>
+    <EFTBasePath>C:\Battlestate Games\sptarkov</EFTBasePath>
+    <EFTDataPath>$(EFTBasePath)\EscapeFromTarkov_Data</EFTDataPath>
+    <EFTManagedPath>$(EFTDataPath)\Managed</EFTManagedPath>
+    <EFTBepInExPath>$(EFTBasePath)\BepInEx</EFTBepInExPath>
+    <EFTBepInExCorePath>$(EFTBepInExPath)\core</EFTBepInExCorePath>
+    <EFTBepInExPluginsPath>$(EFTBepInExPath)\plugins</EFTBepInExPluginsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Unity -->
+    <Reference Include="UnityEngine">
+      <HintPath>$(EFTManagedPath)\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(EFTManagedPath)\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <!-- BepInEx -->
+    <Reference Include="BepInEx">
+      <HintPath>$(EFTBepInExCorePath)\BepInEx.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AkiEftTrainerPlugin.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLog.EFT.Trainer.csproj">
+      <Project>{f4eb56b6-f914-11e9-aad5-362b9e155667}</Project>
+      <Name>NLog.EFT.Trainer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy /Y "$(TargetPath)" "$(EFTBepInExPluginsPath)"</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/BepInExPlugin/BepInExPlugin.csproj
+++ b/BepInExPlugin/BepInExPlugin.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AkiEftTrainerPlugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NLog.EFT.Trainer.csproj">

--- a/BepInExPlugin/Properties/AssemblyInfo.cs
+++ b/BepInExPlugin/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyProduct("Installer")]
+[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyProduct("EFT Trainer, BepInEx plugin")]
 [assembly: AssemblyCopyright("Copyright © 2022 Sebastien Lebreton")]

--- a/EFT.Trainer.sln
+++ b/EFT.Trainer.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29418.71
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.EFT.Trainer", "NLog.EFT.Trainer.csproj", "{F4EB56B6-F914-11E9-AAD5-362B9E155667}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Installer", "Installer\Installer.csproj", "{C7DC685F-89CE-4BA1-8F95-41DA8E18F585}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{992CA551-BFD6-402D-B0B9-039322F16C29}"
+	ProjectSection(SolutionItems) = preProject
+		BepInExPlugin\BepInExPlugin.csproj = BepInExPlugin\BepInExPlugin.csproj
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/EFT.Trainer.sln
+++ b/EFT.Trainer.sln
@@ -7,10 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.EFT.Trainer", "NLog.EF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Installer", "Installer\Installer.csproj", "{C7DC685F-89CE-4BA1-8F95-41DA8E18F585}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{992CA551-BFD6-402D-B0B9-039322F16C29}"
-	ProjectSection(SolutionItems) = preProject
-		BepInExPlugin\BepInExPlugin.csproj = BepInExPlugin\BepInExPlugin.csproj
-	EndProjectSection
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BepInExPlugin", "BepInExPlugin\BepInExPlugin.csproj", "{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +28,12 @@ Global
 		{C7DC685F-89CE-4BA1-8F95-41DA8E18F585}.DebugPerformance|Any CPU.Build.0 = Debug|Any CPU
 		{C7DC685F-89CE-4BA1-8F95-41DA8E18F585}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7DC685F-89CE-4BA1-8F95-41DA8E18F585}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}.DebugPerformance|Any CPU.ActiveCfg = Debug|Any CPU
+		{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}.DebugPerformance|Any CPU.Build.0 = Debug|Any CPU
+		{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00C66BBD-ED7F-4E01-B7E4-0388F76FD31C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Installer/CompilationContext.cs
+++ b/Installer/CompilationContext.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO.Compression;
+
+#nullable enable
+
+namespace Installer
+{
+	internal class CompilationContext
+	{
+		public int Try { get; set; } = 0;
+		public Installation Installation { get; set; }
+		public string ProjectTitle { get; set; }
+		public string Project { get; set; }
+		public string Branch { get; set; } = "master";
+		public string[] Exclude { get; set; } = Array.Empty<string>();
+		public ZipArchive? Archive { get; set; }
+
+		public CompilationContext(Installation installation, string projectTitle, string project)
+		{
+			Installation = installation;
+			ProjectTitle = projectTitle;
+			Project = project;
+		}
+	}
+}

--- a/Installer/Compiler.cs
+++ b/Installer/Compiler.cs
@@ -161,10 +161,8 @@ namespace Installer
 			}
 		}
 
-		public CSharpCompilation Compile()
+		public CSharpCompilation Compile(string assemblyName)
 		{
-			const string assemblyName = "NLog.EFT.Trainer";
-			
 			var syntaxTrees = GetSyntaxTrees()
 				.ToArray();
 

--- a/Installer/ExitCode.cs
+++ b/Installer/ExitCode.cs
@@ -6,14 +6,17 @@
 		NoInstallationFound = 1,
 		CompilationFailed = 2,
 		Canceled = 3,
+		PluginCompilationFailed = 4,
 		Failure = 6,
 
 		CreateDllFailed = 10,
 		CreateOutlineFailed = 11,
 		CreateHarmonyDllFailed = 12,
+		CreatePluginDllFailed = 13,
 
 		RemoveDllFailed = 20,
 		RemoveOutlineFailed = 21,
 		RemoveHarmonyDllFailed = 22,
+		RemovePluginDllFailed = 23,
 	}
 }

--- a/Installer/InstallCommand.cs
+++ b/Installer/InstallCommand.cs
@@ -190,7 +190,7 @@ namespace Installer
 				.Start($"Compiling {context.ProjectTitle}", _ =>
 				{
 					var compiler = new Compiler(archive, context);
-					compilation = compiler.Compile();
+					compilation = compiler.Compile(Path.GetFileNameWithoutExtension(context.Project));
 					errors = compilation
 						.GetDiagnostics()
 						.Where(d => d.Severity == DiagnosticSeverity.Error)

--- a/Installer/InstallCommand.cs
+++ b/Installer/InstallCommand.cs
@@ -34,7 +34,7 @@ namespace Installer
 			public string[]? DisabledFeatures { get; set; }
 		}
 
-		public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+		public override async Task<int> ExecuteAsync(CommandContext commandContext, Settings settings)
 		{
 			try
 			{
@@ -53,34 +53,7 @@ namespace Installer
 					.Select(f => $"{features}\\{f}.cs")
 					.ToArray();
 
-				// Try first to compile against master
-				var @try = 0;
-				var (compilation, archive, errors) = await GetCompilationAsync(++@try, installation, "master", settings.DisabledFeatures);
-				var files = errors
-					.Select(d => d.Location.SourceTree?.FilePath)
-					.Where(s => s is not null)
-					.Distinct()
-					.ToArray();
-
-				if (compilation == null)
-				{
-					// Failure, so try with a dedicated branch if exists
-					var branch = settings.Branch ?? installation.Version.ToString();
-					if (!branch.StartsWith("dev-"))
-						branch = "dev-" + branch;
-
-					(compilation, archive, _) = await GetCompilationAsync(++@try, installation, branch, settings.DisabledFeatures);
-				}
-
-				if (compilation == null && files.Any() && files.All(f => f!.StartsWith(features)))
-				{
-					// Failure, retry by removing faulting features if possible
-					AnsiConsole.MarkupLine($"[yellow]Trying to disable faulting feature(s): [red]{string.Join(", ", files.Select(Path.GetFileNameWithoutExtension))}[/].[/]");
-					(compilation, archive, errors) = await GetCompilationAsync(++@try, installation, "master", files.Concat(settings.DisabledFeatures).ToArray()!);
-
-					if (!errors.Any())
-						AnsiConsole.MarkupLine("[yellow]We found a fallback! But please file an issue here : https://github.com/sailro/EscapeFromTarkov-Trainer/issues [/]");
-				}
+				var (compilation, archive) = await BuildTrainer(settings, installation, features);
 
 				if (compilation == null)
 				{
@@ -99,7 +72,7 @@ namespace Installer
 						return (int)ExitCode.Canceled;
 				}
 
-				if (!CreateDll(installation, "NLog.EFT.Trainer.dll", (dllPath) => compilation.Emit(dllPath)))
+				if (!CreateDll(installation, "NLog.EFT.Trainer.dll", dllPath => compilation.Emit(dllPath)))
 					return (int)ExitCode.CreateDllFailed;
 
 				if (!CreateDll(installation, "0Harmony.dll", dllPath => File.WriteAllBytes(dllPath, Resources._0Harmony), false))
@@ -108,7 +81,28 @@ namespace Installer
 				if (!CreateOutline(installation, archive!))
 					return (int)ExitCode.CreateOutlineFailed;
 
-				CreateOrPatchConfiguration(installation);
+				const string bepInExPluginProject = "BepInExPlugin.csproj";
+				if (installation.UsingBepInEx && archive!.Entries.Any(e => e.Name == bepInExPluginProject))
+				{
+					AnsiConsole.MarkupLine("[yellow]BepInEx detected. Creating plugin instead of using NLog configuration.[/]");
+
+					// reuse successful context for compiling.
+					var pluginContext = new CompilationContext(installation, "plugin", bepInExPluginProject) { Archive = archive };
+					var (pluginCompilation, _, _) = await GetCompilationAsync(pluginContext);
+
+					if (pluginCompilation == null)
+					{
+						AnsiConsole.MarkupLine($"[red]Unable to compile plugin for version {installation.Version}. Please file an issue here : https://github.com/sailro/EscapeFromTarkov-Trainer/issues [/]");
+						return (int)ExitCode.PluginCompilationFailed;
+					}
+
+					if (!CreateDll(installation, Path.Combine(installation.BepInExPlugins, "aki-efttrainer.dll"), dllPath => pluginCompilation.Emit(dllPath)))
+						return (int)ExitCode.CreatePluginDllFailed;
+				}
+				else
+				{
+					CreateOrPatchConfiguration(installation);
+				}
 
 				TryCreateGameDocumentFolder();
 			}
@@ -119,6 +113,47 @@ namespace Installer
 			}
 
 			return (int)ExitCode.Success;
+		}
+
+		private static async Task<(CSharpCompilation?, ZipArchive?)> BuildTrainer(Settings settings, Installation installation, string features)
+		{
+			// Try first to compile against master
+			var context = new CompilationContext(installation, "trainer", "NLog.EFT.Trainer.csproj")
+			{
+				Exclude = settings.DisabledFeatures!
+			};
+
+			var (compilation, archive, errors) = await GetCompilationAsync(context);
+			var files = errors
+				.Select(d => d.Location.SourceTree?.FilePath)
+				.Where(s => s is not null)
+				.Distinct()
+				.ToArray();
+
+			if (compilation == null)
+			{
+				// Failure, so try with a dedicated branch if exists
+				context.Branch = settings.Branch ?? installation.Version.ToString();
+				if (!context.Branch.StartsWith("dev-"))
+					context.Branch = "dev-" + context.Branch;
+
+				(compilation, archive, _) = await GetCompilationAsync(context);
+			}
+
+			if (compilation == null && files.Any() && files.All(f => f!.StartsWith(features)))
+			{
+				// Failure, retry by removing faulting features if possible
+				AnsiConsole.MarkupLine($"[yellow]Trying to disable faulting feature(s): [red]{string.Join(", ", files.Select(Path.GetFileNameWithoutExtension))}[/].[/]");
+				context.Exclude = files.Concat(settings.DisabledFeatures!).ToArray()!;
+				context.Branch = "master";
+
+				(compilation, archive, errors) = await GetCompilationAsync(context);
+
+				if (!errors.Any())
+					AnsiConsole.MarkupLine("[yellow]We found a fallback! But please file an issue here : https://github.com/sailro/EscapeFromTarkov-Trainer/issues [/]");
+			}
+
+			return (compilation, archive);
 		}
 
 		private static void TryCreateGameDocumentFolder()
@@ -138,20 +173,23 @@ namespace Installer
 			}
 		}
 
-		private static async Task<(CSharpCompilation?, ZipArchive?, Diagnostic[])> GetCompilationAsync(int @try, Installation installation, string branch, params string[] exclude)
+		private static async Task<(CSharpCompilation?, ZipArchive?, Diagnostic[])> GetCompilationAsync(CompilationContext context)
 		{
 			var errors = Array.Empty<Diagnostic>();
 
-			var archive = await GetSnapshotAsync(@try, branch);
+			var archive = context.Archive ?? await GetSnapshotAsync(context.Try, context.Branch);
 			if (archive == null)
+			{
+				context.Try++;
 				return (null, null, errors);
+			}
 
 			CSharpCompilation? compilation = null;
 			AnsiConsole
 				.Status()
-				.Start("Compiling trainer", _ =>
+				.Start($"Compiling {context.ProjectTitle}", _ =>
 				{
-					var compiler = new Compiler(archive, installation, exclude);
+					var compiler = new Compiler(archive, context);
 					compilation = compiler.Compile();
 					errors = compilation
 						.GetDiagnostics()
@@ -165,15 +203,16 @@ namespace Installer
 
 					if (errors.Any())
 					{
-						AnsiConsole.MarkupLine($">> [blue]Try #{@try}[/] [yellow]Compilation failed for {branch.EscapeMarkup()} branch.[/]");
+						AnsiConsole.MarkupLine($">> [blue]Try #{context.Try}[/] [yellow]Compilation failed for {context.Branch.EscapeMarkup()} branch.[/]");
 						compilation = null;
 					}
 					else
 					{
-						AnsiConsole.MarkupLine($">> [blue]Try #{@try}[/] Compilation [green]succeed[/] for [blue]{branch.EscapeMarkup()}[/] branch.");
+						AnsiConsole.MarkupLine($">> [blue]Try #{context.Try}[/] Compilation [green]succeed[/] for [blue]{context.Branch.EscapeMarkup()}[/] branch.");
 					}
 				});
 
+			context.Try++;
 			return (compilation, archive, errors);
 		}
 
@@ -295,9 +334,15 @@ namespace Installer
 
 		private static bool CreateDll(Installation installation, string filename, Action<string> creator, bool overwrite = true)
 		{
-			var dllPath = Path.Combine(installation.Managed, filename);
+			var dllPath = Path.IsPathRooted(filename) ? filename : Path.Combine(installation.Managed, filename);
+			var dllPathBepInExCore = Path.IsPathRooted(filename) ? null : Path.Combine(installation.BepInExCore, filename);
+
 			try
 			{
+				// Check for prerequisites, already provided by BepInEx
+				if (dllPathBepInExCore != null && File.Exists(dllPathBepInExCore))
+					return true;
+
 				if (!overwrite && File.Exists(dllPath))
 					return true;
 

--- a/Installer/Installation.cs
+++ b/Installer/Installation.cs
@@ -15,9 +15,13 @@ namespace Installer
 	{
 		public Version Version { get; }
 		public bool UsingSptAki { get; private set; }
+		public bool UsingBepInEx { get; private set; }
 		public string Location { get; }
 		public string Data => Path.Combine(Location, "EscapeFromTarkov_Data");
 		public string Managed => Path.Combine(Data, "Managed");
+		public string BepInEx => Path.Combine(Location, "BepInEx");
+		public string BepInExCore => Path.Combine(BepInEx, "core");
+		public string BepInExPlugins => Path.Combine(BepInEx, "plugins");
 
 		private Installation(string location, Version version)
 		{
@@ -133,6 +137,8 @@ namespace Installer
 
 				var akiFolder = Path.Combine(path, "Aki_Data");
 				installation.UsingSptAki = Directory.Exists(akiFolder);
+
+				installation.UsingBepInEx = Directory.Exists(installation.BepInExPlugins);
 
 				return true;
 			}

--- a/Installer/Installer.csproj
+++ b/Installer/Installer.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\Extensions\NotNullWhenAttribute.cs">
       <Link>NotNullWhenAttribute.cs</Link>
     </Compile>
+    <Compile Include="CompilationContext.cs" />
     <Compile Include="Compiler.cs" />
     <Compile Include="ExitCode.cs" />
     <Compile Include="Installation.cs" />

--- a/Installer/UninstallCommand.cs
+++ b/Installer/UninstallCommand.cs
@@ -47,6 +47,9 @@ namespace Installer
 				if (!RemoveFile(Path.Combine(installation.Data, "outline")))
 					return (int)ExitCode.RemoveOutlineFailed;
 
+				if (!RemoveFile(Path.Combine(installation.BepInExPlugins, "aki-efttrainer.dll")))
+					return (int)ExitCode.RemovePluginDllFailed;
+
 				RemoveOrPatchConfiguration(installation);
 			}
 			catch (Exception ex)

--- a/Loader.cs
+++ b/Loader.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace EFT.Trainer
 {
-	internal class Loader
+	public class Loader
 	{
 		private static GameObject HookObject
 		{

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 
 [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyProduct("EFT Trainer")]
-[assembly: AssemblyCopyright("Copyright © 2021 Sebastien Lebreton")]
+[assembly: AssemblyCopyright("Copyright © 2022 Sebastien Lebreton")]


### PR DESCRIPTION
Fixes #270 when using SptAki. 
Fixes #41

When used live with EFT `0.13.1.21531`, using the legacy NLog configuration (so not working anymore):
![image](https://user-images.githubusercontent.com/638167/211081245-06515ae3-ce02-4421-a271-57ff4f6e905c.png)

When used with spt-aki `3.4.1`:
![image](https://user-images.githubusercontent.com/638167/211080959-b61bdc14-1af6-4ee3-9a9a-3d8f02c629f9.png)

```
[Message:   BepInEx] BepInEx 5.4.21.0 - EscapeFromTarkov (1/6/2023 3:32:33 PM)
[Info   :   BepInEx] Running under Unity v0.12.12.2076
[Info   :   BepInEx] CLR runtime version: 4.0.30319.42000
[Info   :   BepInEx] Supports SRE: True
[Info   :   BepInEx] System platform: Bits64, Windows
[Message:   BepInEx] Preloader started
[Info   :   BepInEx] Loaded 1 patcher method from [BepInEx.Preloader 5.4.21.0]
[Info   :   BepInEx] Loaded 1 patcher method from [aki_PrePatch 1.0.0.0]
[Info   :   BepInEx] 2 patcher plugins loaded
[Info   :   BepInEx] Patching [UnityEngine.CoreModule] with [BepInEx.Chainloader]
[Info   :   BepInEx] Patching [Assembly-CSharp] with [Aki.PrePatch.AkiBotsPrePatcher]
[Message:   BepInEx] Preloader finished
[Message:   BepInEx] Chainloader ready
[Message:   BepInEx] Chainloader started
[Info   :   BepInEx] 6 plugins to load
[Info   :   BepInEx] Loading [Configuration Manager 16.4.1]
[Info   :   BepInEx] Loading [AKI.Core 1.0.0]
[Info   :  AKI.Core] Loading: Aki.Core
[Info   :   BepInEx] Loading [AKI.Custom 1.0.0]
[Info   :   BepInEx] Loading [AKI.EftTrainer 1.0.0]  <==================
[Info   :   BepInEx] Loading [AKI.Singleplayer 1.0.0]
[Message:   BepInEx] Chainloader startup complete
```