### PR TITLE
Corpse search fix

### DIFF
--- a/Features/LootItems.cs
+++ b/Features/LootItems.cs
@@ -140,10 +140,8 @@ namespace EFT.Trainer.Features
 				if (lootItem is Corpse corpse)
 				{
 					if (ShowCorpses)
-					{
 						AddCorpse(lootItem.Item, records, camera, position);
-						continue;
-					}
+						
 					if (SearchInsideCorpses)
 						FindItemsInRootItem(records, camera, corpse.ItemOwner?.RootItem, position);
 


### PR DESCRIPTION
Removed the continue from ShowCorpses check. This broke searching inside corpses for items that are tracked.