### PR TITLE
Unlimited Ammo - First attempt

### DIFF
--- a/Features/UnlimitedAmmo.cs
+++ b/Features/UnlimitedAmmo.cs
@@ -1,0 +1,65 @@
+﻿using Comfort.Common;
+using EFT.InventoryLogic;
+using EFT.Trainer.Extensions;
+using JetBrains.Annotations;
+using System;
+
+#nullable enable
+
+namespace EFT.Trainer.Features
+{
+	[UsedImplicitly]
+	internal class UnlimitedAmmo : ToggleFeature
+	{
+		public override string Name => "unlammo";
+
+		public override bool Enabled { get; set; } = false;
+
+
+		protected override void UpdateWhenEnabled()
+		{
+			var player = GameState.Current?.LocalPlayer;
+			if (!player.IsValid())
+				return;
+
+			if (player.HandsController.Item is not Weapon weapon)
+				return;
+
+			var world = Singleton<GameWorld>.Instance;
+			if (world == null)
+				return;
+
+			var sbc = world.SharedBallisticsCalculator;
+			if (sbc == null)
+				return;
+
+			for (int shotIndex = 0; shotIndex < sbc.ActiveShotsCount; shotIndex++)
+			{
+				var shot = sbc.GetActiveShot(shotIndex);
+				if (shot == null)
+					continue;
+
+				if (shot.IsShotFinished)
+					continue;
+
+				// Make sur we are not enhancing ennemy shots
+				if (shot.Player.IsValid() && !shot.Player.IsYourPlayer)
+					continue;
+
+				MagazineClass currentMagazine = weapon.GetCurrentMagazine();
+
+				if (currentMagazine != null)
+				{
+					var instantiated = Singleton<ItemFactory>.Instantiated;
+					if (instantiated)
+					{
+						ItemFactory instance = Singleton<ItemFactory>.Instance;
+						var itemId = Guid.NewGuid().ToString("N").Substring(0, 24);
+						StackSlot cartridges = currentMagazine.Cartridges;
+						cartridges?.Add(instance.CreateItem(itemId, shot.Ammo.TemplateId, null) ?? shot.Ammo, false);
+					}
+				}
+			}
+		}
+	}
+}

--- a/NLog.EFT.Trainer.csproj
+++ b/NLog.EFT.Trainer.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Features\ToggleFeature.cs" />
     <Compile Include="Features\TrackedItem.cs" />
     <Compile Include="Features\TriggerFeature.cs" />
+    <Compile Include="Features\UnlimitedAmmo.cs" />
     <Compile Include="Features\WallShoot.cs" />
     <Compile Include="Features\Skills.cs" />
     <Compile Include="Features\WorldInteractiveObjects.cs" />


### PR DESCRIPTION
Functional except for revolvers and single shot weapons (MP-18, Rhino, maybe the Rsh?).  Duplicates ammo if less than full magazine due to the hack of just looking at all shots in the game same as the wallshoot. The correct method is to patch BallisticsCalculator.Shoot with Harmony but my understanding of how to do that in CSharp is minimal at best.

Below is as far as I got with the Harmony patch but I couldn't figure out the last bit to actually patch the method.

```csharp
[UsedImplicitly]
protected static bool ShootPrefix(object ammo, Player player)
{
	var feature = FeatureFactory.GetFeature<UnlimitedAmmo>();
	if (feature == null || !feature.Enabled)
		return true; // keep using original code, we are not enabled

	return false;  // skip the original code and all other prefix methods 
}
	HarmonyPatchOnce(harmony =>
	{
		var original = HarmonyLib.AccessTools.Method(typeof(BallisticsCalculator), nameof(BallisticsCalculator.Shoot));
		if (original == null)
			return;
			var prefix = HarmonyLib.AccessTools.Method(GetType(), nameof(ShootPrefix));
		if (prefix == null)
			return;
		harmony.Patch(original, new HarmonyLib.HarmonyMethod(prefix));
	});
	// Add trigger on player shoot here

		MagazineClass currentMagazine = weapon.GetCurrentMagazine();

		if (currentMagazine != null)
		{
			var instantiated = Singleton<ItemFactory>.Instantiated;
			if (instantiated)
			{
				ItemFactory instance = Singleton<ItemFactory>.Instance;
				var itemId = Guid.NewGuid().ToString("N").Substring(0, 24);
				StackSlot cartridges = currentMagazine.Cartridges;
				cartridges?.Add(instance.CreateItem(itemId, shot.Ammo.TemplateId, null) ?? shot.Ammo, false);
			}
```