### PR TITLE
Prototype Demi-god mode

### DIFF
--- a/Features/Health.cs
+++ b/Features/Health.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using EFT.Trainer.Configuration;
 using EFT.Trainer.Extensions;
 using EFT.Trainer.Model;
 using JetBrains.Annotations;
-using UnityEngine;
 
 #nullable enable
 
@@ -28,11 +25,9 @@ namespace EFT.Trainer.Features
 		public bool FoodWater { get; set; } = true;
 
 		private static readonly Array _bodyParts = Enum.GetValues(typeof(EBodyPart));
-
-		private static String[] TargetBones = { "head", "spine3", "spine2", "spine1" };
-
+		
 		[UsedImplicitly]
-		protected static bool ApplyDamagePrefix(object? __instance, ref float __result)
+		protected static bool ApplyDamagePrefix(EBodyPart bodyPart, object? __instance, ref float __result)
 		{
 			var feature = FeatureFactory.GetFeature<Health>();
 			if (feature == null || !feature.Enabled || __instance == null)
@@ -46,34 +41,15 @@ namespace EFT.Trainer.Features
 			
 			if (feature.VitalsOnly)
 			{
-				__result = 0.01f; // hack to allow damage but not enough to kill you. Should probably look at the body part about to receive damage and set to zero
-				return true;
+				if (bodyPart == EBodyPart.Chest || bodyPart == EBodyPart.Head)
+				{
+					__result = 0f;
+					return false; // skip the original code because we must protect the head and chest
+				}
+				return true; // keep using original code, apply damage to extremities 
 			}
-				__result = 0f;
+			__result = 0f;
 			return false;  // skip the original code and all other prefix methods 
-		}
-
-		private static IEnumerable<Transform> EnumerateHierarchyCore(Transform root)
-		{
-			Queue<Transform> transformQueue = new Queue<Transform>();
-			transformQueue.Enqueue(root);
-
-			while (transformQueue.Count > 0)
-			{
-				Transform parentTransform = transformQueue.Dequeue();
-
-				if (!parentTransform)
-				{
-					continue;
-				}
-
-				for (Int32 i = 0; i < parentTransform.childCount; i++)
-				{
-					transformQueue.Enqueue(parentTransform.GetChild(i));
-				}
-
-				yield return parentTransform;
-			}
 		}
 
 		protected override void UpdateWhenEnabled()
@@ -99,20 +75,8 @@ namespace EFT.Trainer.Features
 				harmony.Patch(original, new HarmonyLib.HarmonyMethod(prefix));
 			});
 
-			if (VitalsOnly)
-			{
-				foreach (Transform transform in Health.EnumerateHierarchyCore(player.gameObject.transform).Where(t => TargetBones.Any(u => t.name.ToLower().Contains(u))))
-				{
-					if (transform.gameObject.layer != LayerMask.NameToLayer("PlayerSpiritAura"))
-					{
-						transform.gameObject.layer = LayerMask.NameToLayer("PlayerSpiritAura"); // Theoretically makes it impossible to hit your head/chest. Can still die from collateral damage.
-					}
-				}
-			}
-
 			foreach (EBodyPart bodyPart in _bodyParts)
 			{
-
 				if (bodyPart == EBodyPart.Common)
 					continue;
 
@@ -124,8 +88,8 @@ namespace EFT.Trainer.Features
 
 				if (RemoveNegativeEffects)
 				{
-					healthController.RemoveNegativeEffects(EBodyPart.Common);
 					healthController.RemoveNegativeEffects(bodyPart);
+					healthController.RemoveNegativeEffects(EBodyPart.Common);
 				}
 
 				var bodyPartHealth = healthController.GetBodyPartHealth(bodyPart);
@@ -145,6 +109,7 @@ namespace EFT.Trainer.Features
 
 			if (!healthController.Hydration.AtMaximum && FoodWater)
 				healthController.ChangeHydration(healthController.Hydration.Maximum);
+
 		}
 	}
 }

--- a/Features/Health.cs
+++ b/Features/Health.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EFT.Trainer.Configuration;
 using EFT.Trainer.Extensions;
 using EFT.Trainer.Model;
 using JetBrains.Annotations;
+using UnityEngine;
 
 #nullable enable
 
@@ -14,7 +18,18 @@ namespace EFT.Trainer.Features
 
 		public override bool Enabled { get; set; } = false;
 
+		[ConfigurationProperty]
+		public bool VitalsOnly { get; set; } = false;
+
+		[ConfigurationProperty]
+		public bool RemoveNegativeEffects { get; set; } = true;
+
+		[ConfigurationProperty]
+		public bool FoodWater { get; set; } = true;
+
 		private static readonly Array _bodyParts = Enum.GetValues(typeof(EBodyPart));
+
+		private static String[] TargetBones = { "head", "spine3", "spine2", "spine1" };
 
 		[UsedImplicitly]
 		protected static bool ApplyDamagePrefix(object? __instance, ref float __result)
@@ -25,12 +40,40 @@ namespace EFT.Trainer.Features
 
 			var healthControllerWrapper = new HealthControllerWrapper(__instance);
 			var player = healthControllerWrapper.Player;
-
+			
 			if (player == null || !player.IsYourPlayer)
 				return true; // keep using original code, apply damage to others
-
-			__result = 0f;
+			
+			if (feature.VitalsOnly)
+			{
+				__result = 0.01f; // hack to allow damage but not enough to kill you. Should probably look at the body part about to receive damage and set to zero
+				return true;
+			}
+				__result = 0f;
 			return false;  // skip the original code and all other prefix methods 
+		}
+
+		private static IEnumerable<Transform> EnumerateHierarchyCore(Transform root)
+		{
+			Queue<Transform> transformQueue = new Queue<Transform>();
+			transformQueue.Enqueue(root);
+
+			while (transformQueue.Count > 0)
+			{
+				Transform parentTransform = transformQueue.Dequeue();
+
+				if (!parentTransform)
+				{
+					continue;
+				}
+
+				for (Int32 i = 0; i < parentTransform.childCount; i++)
+				{
+					transformQueue.Enqueue(parentTransform.GetChild(i));
+				}
+
+				yield return parentTransform;
+			}
 		}
 
 		protected override void UpdateWhenEnabled()
@@ -56,27 +99,51 @@ namespace EFT.Trainer.Features
 				harmony.Patch(original, new HarmonyLib.HarmonyMethod(prefix));
 			});
 
+			if (VitalsOnly)
+			{
+				foreach (Transform transform in Health.EnumerateHierarchyCore(player.gameObject.transform).Where(t => TargetBones.Any(u => t.name.ToLower().Contains(u))))
+				{
+					if (transform.gameObject.layer != LayerMask.NameToLayer("PlayerSpiritAura"))
+					{
+						transform.gameObject.layer = LayerMask.NameToLayer("PlayerSpiritAura"); // Theoretically makes it impossible to hit your head/chest. Can still die from collateral damage.
+					}
+				}
+			}
+
 			foreach (EBodyPart bodyPart in _bodyParts)
 			{
+
 				if (bodyPart == EBodyPart.Common)
+					continue;
+
+				if (VitalsOnly && !(bodyPart == EBodyPart.Chest || bodyPart == EBodyPart.Head))
 					continue;
 
 				if (healthController.IsBodyPartBroken(bodyPart) || healthController.IsBodyPartDestroyed(bodyPart))
 					healthController.RestoreBodyPart(bodyPart, 0);
 
+				if (RemoveNegativeEffects)
+				{
+					healthController.RemoveNegativeEffects(EBodyPart.Common);
+					healthController.RemoveNegativeEffects(bodyPart);
+				}
+
 				var bodyPartHealth = healthController.GetBodyPartHealth(bodyPart);
 				if (bodyPartHealth.AtMaximum)
 					continue;
 
-				healthController.RestoreFullHealth();
-				healthController.RemoveNegativeEffects(EBodyPart.Common);
+				if (!VitalsOnly)
+					healthController.RestoreFullHealth();
+
+				healthController.ChangeHealth(bodyPart, bodyPartHealth.Maximum, default);
+
 				break;
 			}
 
-			if (!healthController.Energy.AtMaximum)
+			if (!healthController.Energy.AtMaximum && FoodWater)
 				healthController.ChangeEnergy(healthController.Energy.Maximum);
 
-			if (!healthController.Hydration.AtMaximum)
+			if (!healthController.Hydration.AtMaximum && FoodWater)
 				healthController.ChangeHydration(healthController.Hydration.Maximum);
 		}
 	}

--- a/Features/Health.cs
+++ b/Features/Health.cs
@@ -84,7 +84,7 @@ namespace EFT.Trainer.Features
 					continue;
 
 				if (healthController.IsBodyPartBroken(bodyPart) || healthController.IsBodyPartDestroyed(bodyPart))
-					healthController.RestoreBodyPart(bodyPart, 0);
+					healthController.RestoreBodyPart(bodyPart, 1);
 
 				if (RemoveNegativeEffects)
 				{


### PR DESCRIPTION
Also enabled ability to toggle Energy/Hydration drain and removal of negative effects. A little bit hackish for the demi-god mode because I couldn't figure out how to bypass damage if the body part being targeted for damage is  chest/head. One side effect of the negative effect toggle is that all the negative effects are removed but you still limp until you take a stim/medicine etc. Credit to S3RAPH's Tarky Menu for the target bone code.