### PR TITLE
Improve loot performance

### DIFF
--- a/Features/LootItems.cs
+++ b/Features/LootItems.cs
@@ -101,6 +101,11 @@ namespace EFT.Trainer.Features
 					continue;
 
 				var position = container.transform.position;
+
+				var distance = Math.Round(Vector3.Distance(camera.transform.position, position));
+				if (MaximumDistance > 0 && distance > MaximumDistance)
+					continue;
+
 				FindItemsInRootItem(records, camera, container.ItemOwner?.RootItem, position);
 			}
 		}
@@ -136,6 +141,10 @@ namespace EFT.Trainer.Features
 					continue;
 
 				var position = lootItem.transform.position;
+
+				var distance = Math.Round(Vector3.Distance(camera.transform.position, position));
+				if (MaximumDistance > 0 && distance > MaximumDistance)
+					continue;
 
 				if (lootItem is Corpse corpse)
 				{

--- a/Features/LootableContainers.cs
+++ b/Features/LootableContainers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Comfort.Common;
 using EFT.Interactive;
 using EFT.Trainer.Configuration;
@@ -48,6 +49,11 @@ namespace EFT.Trainer.Features
 					continue;
 
 				var position = container.transform.position;
+
+				var distance = Math.Round(Vector3.Distance(camera.transform.position, position));
+				if (MaximumDistance > 0 && distance > MaximumDistance)
+					continue;
+
 				records.Add(new PointOfInterest
 				{
 					Name = container.Template.LocalizedShortName(),


### PR DESCRIPTION
If a container/item is not within our configured maximum distance we should skip further processing. This should allow for lower cache times while not crushing performance due to the vast majority of processing being skipped for containers out of range. Possible fix for #154.