### PR TITLE
Wallhack Changes

### DIFF
--- a/Features/Bones.cs
+++ b/Features/Bones.cs
@@ -78,6 +78,23 @@ namespace EFT.Trainer.Features
 			new [] {RPalm, RDigit11}, new [] {RDigit41, RDigit42}, new [] {RDigit42, RDigit43}, new [] {RPalm, RDigit11}, new [] {RDigit51, RDigit52}, new [] {RDigit52, RDigit53}
 		};
 
+		public static readonly List<string[]> HitConnections = new()
+		{
+			new [] {Pelvis, LThigh1}, new [] {LThigh1, LThigh2}, new [] {LThigh2, LCalf}, new [] {LCalf, LFoot}, new [] {LFoot, LToe}, new [] {Pelvis, RThigh1}, new [] {RThigh1, RThigh2}, new [] {RThigh2, RCalf},
+			new [] {RCalf, RFoot}, new [] {RFoot, RToe}, new [] {Pelvis, Spine1}, new [] {Spine1, Spine2}, new [] {Spine2, Spine3}, new [] {Spine3, Neck}, new [] {Neck, Head}, new [] {Spine3, LCollarbone},
+			new [] {LCollarbone, LForearm1}, new [] {LForearm1, LForearm2}, new [] {LForearm2, LForearm3}, new [] {LForearm3, LPalm}, new [] {RCollarbone, RForearm1}, new [] {RForearm1, RForearm2},
+			new [] {RForearm2, RForearm3}, new [] {RForearm3, RPalm}
+		};
+
+		public static readonly List<string[]> FingerConnections = new()
+		{
+			new [] {LPalm, LDigit11}, new [] {LDigit11, LDigit12}, new [] {LDigit12, LDigit13}, new [] {LPalm, LDigit21}, new [] {LDigit21, LDigit22}, new [] {LDigit22, LDigit23}, new [] {LPalm, LDigit31},
+			new [] {LDigit31, LDigit32}, new [] {LDigit32, LDigit33}, new [] {LPalm, LDigit41}, new [] {LDigit41, LDigit42}, new [] {LDigit42, LDigit43}, new [] {LPalm, LDigit51}, new [] {LDigit51, LDigit52},
+			new [] {LDigit52, LDigit53}, new [] {RPalm, RDigit11}, new [] {RDigit11, RDigit12},	new [] {RDigit12, RDigit13}, new [] {RPalm, RDigit11}, new [] {RDigit21, RDigit22}, new [] {RDigit22, RDigit23},
+			new [] {RPalm, RDigit11}, new [] {RDigit31, RDigit32}, new [] {RDigit32, RDigit33},	new [] {RPalm, RDigit11}, new [] {RDigit41, RDigit42}, new [] {RDigit42, RDigit43}, new [] {RPalm, RDigit11},
+			new [] {RDigit51, RDigit52}, new [] {RDigit52, RDigit53}
+		};
+
 		public static void RenderBone(Dictionary<string, Transform> bones, string from, string to, float thickness, Color color, Camera camera)
 		{
 			RenderBone(bones[from].position, bones[to].position, thickness, color, camera);
@@ -109,6 +126,34 @@ namespace EFT.Trainer.Features
 			var radius = Vector3.Distance(head, neck);
 
 			Render.DrawCircle(new Vector2(head.x, head.y), radius, color, thickness, 8);
+		}
+
+		public static void RenderBones(Player player, float thickness, Color color1, Color color2, Camera camera)
+		{
+			var skeleton = player.PlayerBody.SkeletonRootJoint;
+			if (skeleton == null)
+				return;
+
+			var bones = skeleton.Bones;
+			if (bones == null)
+				return;
+
+			foreach (var connection in HitConnections)
+				if (camera.IsTransformVisible(bones[connection[0]].transform) || camera.IsTransformVisible(bones[connection[1]].transform))
+					RenderBone(bones, connection[0], connection[1], thickness, color1, camera);
+				else
+					RenderBone(bones, connection[0], connection[1], thickness, color2, camera);
+
+			foreach (var connection in FingerConnections)
+				RenderBone(bones, connection[0], connection[1], thickness, color2, camera);
+
+			var head = camera.WorldPointToScreenPoint(bones[Head].position);
+			var neck = camera.WorldPointToScreenPoint(bones[Neck].position);
+			var radius = Vector3.Distance(head, neck);
+			if (camera.IsTransformVisible(bones[Head].transform))
+				Render.DrawCircle(new Vector2(head.x, head.y), radius, color1, thickness, 8);
+			else
+				Render.DrawCircle(new Vector2(head.x, head.y), radius, color2, thickness, 8);
 		}
 	}
 }

--- a/Features/Players.cs
+++ b/Features/Players.cs
@@ -164,19 +164,34 @@ namespace EFT.Trainer.Features
 				if (playerBones == null)
 					continue;
 
+				bool shootable = false;
 				if (ShowShootable)
 				{
-					var shootable = camera.IsTransformVisible(playerBones.Head.Original);
+					Transform[] bonesToCheck = new Transform[13] {
+						playerBones.Head.Original.transform,
+						playerBones.Neck.transform,
+						playerBones.Shoulders[0].transform,
+						playerBones.Shoulders[1].transform,
+						playerBones.Spine1.transform,
+						playerBones.Upperarms[0].transform,
+						playerBones.Upperarms[1].transform,
+						playerBones.Forearms[0].transform,
+						playerBones.Forearms[1].transform,
+						playerBones.LeftThigh1.Original.transform,
+						playerBones.RightThigh1.Original.transform,
+						playerBones.LeftThigh2.Original.transform,
+						playerBones.RightThigh2.Original.transform
+					};
 
-					if (shootable)
+					borderColor = NotShootableBoxColor;
+					foreach (Transform bone in bonesToCheck)
 					{
-						color = ShootableColor;
-						borderColor = ShootableBoxColor;
-					}	
-					else
-					{
-						color = NotShootableColor;
-						borderColor = NotShootableBoxColor;
+						if (camera.IsTransformVisible(bone))
+						{
+							borderColor = ShootableBoxColor;
+							shootable = true;
+							break;
+						}
 					}
 				}
 
@@ -196,7 +211,7 @@ namespace EFT.Trainer.Features
 				var ennemyHealthController = ennemy.HealthController;
 				var ennemyHandController = ennemy.HandsController;
 				if (ShowInfos && ennemyHealthController is {IsAlive: true})
-					{
+				{
 					var bodyPartHealth = ennemyHealthController.GetBodyPartHealth(EBodyPart.Common);
 					var currentPlayerHealth = bodyPartHealth.Current;
 					var maximumPlayerHealth = bodyPartHealth.Maximum;
@@ -205,10 +220,15 @@ namespace EFT.Trainer.Features
 					var infoText = $"{weaponText} {Mathf.Round(currentPlayerHealth * 100 / maximumPlayerHealth)}% [{distance}m]".Trim();
 
 					Render.DrawString(new Vector2(boxPositionX, boxPositionY - 20f), infoText, infoColor, false);
-					}
+				}
 
 				if (ShowSkeletons)
-					Bones.RenderBones(ennemy, SkeletonThickness, color, camera);
+				{
+					if (ShowShootable && shootable)
+						Bones.RenderBones(ennemy, SkeletonThickness, ShootableColor, NotShootableColor, camera);
+					else
+						Bones.RenderBones(ennemy, SkeletonThickness, color, camera);
+				}
 			}
 		}
 


### PR DESCRIPTION
Separates infoColor from color and borderColor. Changes boxes to use borderColor not color. Adds basic Shootable detection and configurable colors, ideally we would enumerate through each part of the enemy we are looking to check if the enemy could be hit but currently the check is only against the Head.

The separate colors and the shootable colors does cause an issue where the options exceed the size of the gui window and doesn't resize. I couldn't figure out where to fix this.

This addresses some of the requests in #299.