### PR TITLE
Add 2D Radar functionality

### DIFF
--- a/Features/Radar.cs
+++ b/Features/Radar.cs
@@ -42,35 +42,18 @@ namespace EFT.Trainer.Features
 		[ConfigurationProperty(Order = 80)]
 		public bool ShowCultists { get; set; } = true;
 
-		[ConfigurationProperty(Order = 90)]
-		public Color BearColors { get; set; } = Color.blue;
-
-		[ConfigurationProperty(Order = 100)]
-		public Color UsecColors { get; set; } = Color.green;
-
-		[ConfigurationProperty(Order = 110)]
-		public Color ScavColors { get; set; } = Color.yellow;
-
-		[ConfigurationProperty(Order = 120)]
-		public Color BossColors { get; set; } = Color.red;
-
-		[ConfigurationProperty(Order = 130)]
-		public Color CultistColors { get; set; } = Color.yellow;
-
-		[ConfigurationProperty(Order = 140)]
-		public Color ScavRaiderColors { get; set; } = Color.yellow;
-
-
-
 		[UsedImplicitly]
 		protected void OnGUI()
 		{
 			if (!Enabled)
 				return;
 
-			var screenPercentage = RadarPercentage / 100f;
-			if (RadarRange <= 0 || screenPercentage > 1)
+			if (RadarRange <= 0)
 				return;
+
+			var screenPercentage = RadarPercentage / 100f;
+			if (screenPercentage > 1)
+				screenPercentage = 1;
 
 			var hostiles = GameState.Current?.Hostiles;
 			if (hostiles == null)
@@ -84,9 +67,15 @@ namespace EFT.Trainer.Features
 			if (camera == null)
 				return;
 
+			var feature = FeatureFactory.GetFeature<Players>();
+			if (feature == null)
+				return;
+
 			var radarSize = Mathf.Sqrt(Screen.height * Screen.width * screenPercentage) / 2;
 			var radarX = Screen.width - radarSize;
 			var radarY = Screen.height - radarSize;
+
+
 
 			foreach (var enemy in hostiles)
 			{
@@ -118,20 +107,19 @@ namespace EFT.Trainer.Features
 
 				var playerColor = hostileType switch
 				{
-					0 => ScavColors,
-					1 => ScavRaiderColors,
-					2 => CultistColors,
-					3 => BossColors,
-					4 => BearColors,
-					5 => UsecColors,
-					_ => ScavColors,
+					0 => feature.ScavColors.Color,
+					1 => feature.ScavRaiderColors.Color,
+					2 => feature.CultistColors.Color,
+					3 => feature.BossColors.Color,
+					4 => feature.BearColors.Color,
+					5 => feature.UsecColors.Color,
+					_ => feature.ScavColors.Color,
 				};
 				
-				DrawRadarEnemy(player, enemy, radarSize, distance, playerColor);
+				DrawRadarEnemy(player, enemy, radarSize, playerColor);
 
 				}
 
-			//To Render Our background
 			Render.DrawCrosshair(new Vector2(radarX + (radarSize / 2), radarY + (radarSize / 2)), radarSize / 2, RadarCrosshair, 2f);
 			Render.DrawBox(radarX, radarY, radarSize, radarSize, 2f, RadarBackground);
 		}
@@ -157,7 +145,6 @@ namespace EFT.Trainer.Features
 					return 3;
 			}
 
-			// it can still be a bot in sptarkov but let's use the pmc color
 			return info.Side switch
 			{
 				EPlayerSide.Bear => 4,
@@ -166,23 +153,47 @@ namespace EFT.Trainer.Features
 			};
 		}
 
-		private void DrawRadarEnemy(Player player, Player enemy, float radarSize, float distance, Color playerColor)
+		private void DrawRadarEnemy(Player player, Player enemy, float radarSize, Color playerColor)
 		{
 			var radarX = Screen.width - radarSize;
 			var radarY = Screen.height - radarSize;
 
-			//Draw Box
-			float enemyY = player.Transform.position.x - enemy.Transform.position.x;
-			float enemyX = player.Transform.position.z - enemy.Transform.position.z;
-			float enemyAtan = Mathf.Atan2(enemyY, enemyX) * Mathf.Rad2Deg - 270 - player.Transform.eulerAngles.y;
+			var playerPosition = player.Transform.position;
+			var enemyPosition = enemy.Transform.position;
+			var playerEulerY = player.Transform.eulerAngles.y;
 
-			float enemyRadarX = distance * Mathf.Cos(enemyAtan * Mathf.Deg2Rad);
-			float enemyRadarY = distance * Mathf.Sin(enemyAtan * Mathf.Deg2Rad);
+			var enemyRadar = FindRadarPoint(playerPosition, enemyPosition, playerEulerY, radarX, radarY, radarSize);
+
+			var enemyOffset = enemyPosition + enemy.LookDirection * 8f;
+			var enemyOffset2 = enemyPosition + (enemy.LookDirection * 4f) + (enemy.MovementContext.PlayerRealRight * 2f);
+			var enemyOffset3 = enemyPosition + (enemy.LookDirection * 4f) - (enemy.MovementContext.PlayerRealRight * 2f);
+
+			var enemyForward = FindRadarPoint(playerPosition, enemyOffset, playerEulerY, radarX, radarY, radarSize);
+			var enemyArrow = FindRadarPoint(playerPosition, enemyOffset2, playerEulerY, radarX, radarY, radarSize);
+			var enemyArrow2 = FindRadarPoint(playerPosition, enemyOffset3, playerEulerY, radarX, radarY, radarSize);
+
+			Render.DrawLine(enemyRadar, enemyForward, 2f, Color.white);
+			Render.DrawLine(enemyArrow, enemyForward, 2f, Color.white);
+			Render.DrawLine(enemyArrow2, enemyForward, 2f, Color.white);
+			Render.DrawCircle(enemyRadar, 10f, playerColor, 2f, 8);
+
+		}
+
+		private Vector2 FindRadarPoint(Vector3 playerPosition, Vector3 enemyPosition, float playerEulerY, float radarX, float radarY, float radarSize)
+		{
+			float enemyY = playerPosition.x - enemyPosition.x;
+			float enemyX = playerPosition.z - enemyPosition.z;
+			float enemyAtan = Mathf.Atan2(enemyY, enemyX) * Mathf.Rad2Deg - 270 - playerEulerY;
+
+			var enemyDistance = Mathf.Round(Vector3.Distance(playerPosition, enemyPosition));
+
+			float enemyRadarX = enemyDistance * Mathf.Cos(enemyAtan * Mathf.Deg2Rad);
+			float enemyRadarY = enemyDistance * Mathf.Sin(enemyAtan * Mathf.Deg2Rad);
 
 			enemyRadarX = enemyRadarX * (radarSize / RadarRange) / 2f;
 			enemyRadarY = enemyRadarY * (radarSize / RadarRange) / 2f;
 
-			Render.DrawCircle(new Vector2(radarX + radarSize / 2f + enemyRadarX, radarY + radarSize / 2f + enemyRadarY), 10f, playerColor, 2f, 8);
+			return new Vector2(radarX + radarSize / 2f + enemyRadarX, radarY + radarSize / 2f + enemyRadarY);
 		}
 	}
 }


### PR DESCRIPTION
Added 2D Radar functionality. Tried to add direction lines from the enemies but couldn't get it to work. Enemies are color matched and do not perform shootable/not shootable detection. RadarPercentage determines what percentage of the screen should be taken for the radar size capped to 50% of the screen size. Ideally this would use colors from the wallhack feature rather than having its own set.

Config panel
![image](https://user-images.githubusercontent.com/769465/221995994-7843a900-993b-4088-908c-e1384a5a383e.png)

Radar
![image](https://user-images.githubusercontent.com/769465/221996173-918ea3b9-12ba-4ac7-8989-e452e276b558.png)


Here is the busted direction line code. I tried numerous iterations of the enemyOffset but all of them behaved in unexpected manners like the line would point at the player or would be behind the enemy. 

```cs
//Draw Line
			 
var enemyOffset = enemy.Transform.position + enemy.Transform.forward * 5f;
float enemyOffsetY = player.Transform.position.x - enemyOffset.x;
float enemyOffsetX = player.Transform.position.z - enemyOffset.z;
float enemyOffsetAtan = Mathf.Atan2(enemyOffsetY, enemyOffsetX) * Mathf.Rad2Deg - 270 - player.Transform.eulerAngles.y;

float enemyForwardY = enemyOffset.x * Mathf.Sin(enemyOffsetAtan * Mathf.Deg2Rad);
float enemyForwardX = enemyOffset.z * Mathf.Cos(enemyOffsetAtan * Mathf.Deg2Rad);

enemyForwardY = enemyForwardY * (radarSize / RadarRange) / 2f;
enemyForwardX = enemyForwardX * (radarSize / RadarRange) / 2f;

Render.DrawLine(new Vector2(radarX + radarSize / 2f + enemyRadarX, radarY + radarSize / 2f + enemyRadarY), new Vector2(radarX + radarSize / 2f + enemyForwardX, radarY + radarSize / 2f + enemyForwardY), 2f, playerColor);
```