### PR TITLE
Map view and Radar map fixes

### DIFF
--- a/Features/BaseMapToggleFeature.cs
+++ b/Features/BaseMapToggleFeature.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using EFT.Trainer.Configuration;
 using EFT.Trainer.Extensions;
 using EFT.Trainer.UI;
+using EFT.UI;
 using UnityEngine;
 
 #nullable enable
@@ -37,6 +39,8 @@ namespace EFT.Trainer.Features
 
 		private GameObject? _mapCameraObject = null;
 		private Camera? _mapCamera = null;
+
+		private static readonly string[] _directions = { "N", "NE", "E", "SE", "S", "SW", "W", "NW", "N" };
 
 		protected void ToggleMapCameraIfNeeded(bool state)
 		{
@@ -86,9 +90,13 @@ namespace EFT.Trainer.Features
 			mapTransform.localPosition = new Vector3(cameraTransform.localPosition.x, range * Mathf.Tan(45), cameraTransform.localPosition.z);
 		}
 
-		protected void DrawHostiles(Camera camera, IEnumerable<Player> hostiles, float x, float y, float sizex, float sizey, float range)
+		protected void DrawHostiles(Camera camera, IEnumerable<Player> hostiles, float range, float x = 0f, float y = 0f, float radarSize = 0f)
 		{
-			var cameraTransform = camera.transform;
+			var cameraPosition = camera.transform.position;
+
+			if (radarSize == 0f)
+				cameraPosition.y = 0f;
+
 			var feature = FeatureFactory.GetFeature<Players>();
 			if (feature == null)
 				return;
@@ -100,7 +108,7 @@ namespace EFT.Trainer.Features
 
 				var position = enemy.Transform.position;
 
-				var distance = Mathf.Round(Vector3.Distance(cameraTransform.position, position));
+				var distance = Mathf.Round(Vector3.Distance(cameraPosition, position));
 				if (range > 0 && distance > range)
 					continue;
 
@@ -118,7 +126,10 @@ namespace EFT.Trainer.Features
 					default:
 					{
 						var playerColor = feature.GetPlayerColors(enemy);
-						DrawEnemy(camera, enemy, x, y, sizex, sizey, range, playerColor.Color);
+							if (radarSize == 0f)
+								DrawEnemy(camera, enemy, playerColor.Color);
+							else
+								DrawEnemy(camera, enemy, range, playerColor.Color, radarSize, x, y);
 						break;
 					}
 				}
@@ -154,7 +165,7 @@ namespace EFT.Trainer.Features
 			};
 		}
 
-		protected static void DrawEnemy(Camera camera, Player enemy, float x, float y, float sizex, float sizey, float range, Color playerColor)
+		protected static void DrawEnemy(Camera camera, Player enemy, float range, Color playerColor, float radarSize, float x, float y)
 		{
 			var cameraTransform = camera.transform;
 			var cameraPosition = cameraTransform.position;
@@ -162,7 +173,8 @@ namespace EFT.Trainer.Features
 			var enemyPosition = enemy.Transform.position;
 			var cameraEulerY = cameraTransform.eulerAngles.y;
 
-			var enemyMap = FindMapPoint(cameraPosition, enemyPosition, cameraEulerY, x, y, sizex, sizey, range);
+			var enemyMap = FindMapPoint(cameraPosition, enemyPosition, cameraEulerY, x, y, radarSize, range);
+			ConsoleScreen.Log(enemyMap.ToString());
 
 			var enemyLookDirection = enemy.LookDirection;
 
@@ -172,9 +184,11 @@ namespace EFT.Trainer.Features
 			var enemyOffset2 = enemyPosition + enemyLookDirection * 4f + playerRealRight * 2f;
 			var enemyOffset3 = enemyPosition + enemyLookDirection * 4f - playerRealRight * 2f;
 
-			var enemyForward = FindMapPoint(cameraPosition, enemyOffset, cameraEulerY, x, y, sizex, sizey, range);
-			var enemyArrow = FindMapPoint(cameraPosition, enemyOffset2, cameraEulerY, x, y, sizex, sizey, range);
-			var enemyArrow2 = FindMapPoint(cameraPosition, enemyOffset3, cameraEulerY, x, y, sizex, sizey, range);
+			var enemyForward = FindMapPoint(cameraPosition, enemyOffset, cameraEulerY, x, y, radarSize, range);
+			var enemyArrow = FindMapPoint(cameraPosition, enemyOffset2, cameraEulerY, x, y, radarSize, range);
+			var enemyArrow2 = FindMapPoint(cameraPosition, enemyOffset3, cameraEulerY, x, y, radarSize, range);
+
+			var enemyPosition2 = camera.WorldPointToScreenPoint(enemyPosition);
 
 			Render.DrawLine(enemyMap, enemyForward, 2f, Color.white);
 			Render.DrawLine(enemyArrow, enemyForward, 2f, Color.white);
@@ -182,7 +196,44 @@ namespace EFT.Trainer.Features
 			Render.DrawCircle(enemyMap, 10f, playerColor, 2f, 8);
 		}
 
-		private static Vector2 FindMapPoint(Vector3 playerPosition, Vector3 enemyPosition, float playerEulerY, float x, float y, float sizex, float sizey, float range)
+		protected static void DrawEnemy(Camera camera, Player enemy, Color playerColor)
+		{
+			var radarMiniMap = false;
+			if (camera.name == "EFT.Trainer.Features.Radar_mapCamera")
+				radarMiniMap = true;
+
+			var enemyPosition = enemy.Transform.position;
+						
+			var enemyMap = radarMiniMap ? camera.WorldToScreenPoint(enemyPosition) : camera.WorldPointToScreenPoint(enemyPosition);
+			ConsoleScreen.Log(enemyMap.ToString());
+
+			var enemyLookDirection = enemy.LookDirection;
+
+			var enemyOffset = enemyPosition + enemyLookDirection * 8f;
+			var playerRealRight = enemy.MovementContext.PlayerRealRight;
+
+			var enemyOffset2 = enemyPosition + enemyLookDirection * 4f + playerRealRight * 2f;
+			var enemyOffset3 = enemyPosition + enemyLookDirection * 4f - playerRealRight * 2f;
+
+			var enemyForward = radarMiniMap ? camera.WorldToScreenPoint(enemyOffset) : camera.WorldPointToScreenPoint(enemyOffset);
+			var enemyArrow = radarMiniMap ? camera.WorldToScreenPoint(enemyOffset2) : camera.WorldPointToScreenPoint(enemyOffset2);
+			var enemyArrow2 = radarMiniMap ? camera.WorldToScreenPoint(enemyOffset3) : camera.WorldPointToScreenPoint(enemyOffset3);
+
+			if (radarMiniMap)
+			{
+				enemyMap.y = Screen.height - enemyMap.y;
+				enemyForward.y = Screen.height - enemyForward.y;
+				enemyArrow.y = Screen.height - enemyArrow.y;
+				enemyArrow2.y = Screen.height - enemyArrow2.y;
+			}
+
+			Render.DrawLine(enemyMap, enemyForward, 2f, Color.white);
+			Render.DrawLine(enemyArrow, enemyForward, 2f, Color.white);
+			Render.DrawLine(enemyArrow2, enemyForward, 2f, Color.white);
+			Render.DrawCircle(enemyMap, 10f, playerColor, 2f, 8);
+		}
+
+		private static Vector2 FindMapPoint(Vector3 playerPosition, Vector3 enemyPosition, float playerEulerY, float x, float y, float radarSize, float range)
 		{
 			float enemyY = playerPosition.x - enemyPosition.x;
 			float enemyX = playerPosition.z - enemyPosition.z;
@@ -193,10 +244,16 @@ namespace EFT.Trainer.Features
 			float enemyMapX = enemyDistance * Mathf.Cos(enemyAtan * Mathf.Deg2Rad);
 			float enemyMapY = enemyDistance * Mathf.Sin(enemyAtan * Mathf.Deg2Rad);
 
-			enemyMapX = enemyMapX * (sizex / range) / 2f;
-			enemyMapY = enemyMapY * (sizey / range) / 2f;
+			enemyMapX = enemyMapX * (radarSize / range) / 2f;
+			enemyMapY = enemyMapY * (radarSize / range) / 2f;
 
-			return new Vector2(x + sizex / 2f + enemyMapX, y + sizey / 2f + enemyMapY);
+			return new Vector2(x + radarSize / 2f + enemyMapX, y + radarSize / 2f + enemyMapY);
+		}
+
+		protected static string GetHeadingAngle(Vector3 direction)
+		{
+			var heading = Quaternion.LookRotation(direction).eulerAngles.y;
+			return _directions[(int)Math.Round((double)heading % 360 / 45)];
 		}
 	}
 }

--- a/Features/Map.cs
+++ b/Features/Map.cs
@@ -16,6 +16,8 @@ namespace EFT.Trainer.Features
 		[ConfigurationProperty(Order = 20)]
 		public float Range { get; set; } = 400f;
 
+		private Camera? _mapCamera = null;
+
 		protected override void OnGUIWhenEnabled()
 		{
 			if (Range <= 0)
@@ -38,7 +40,21 @@ namespace EFT.Trainer.Features
 			SetupMapCamera(camera, 0, 0, width, height);
 			UpdateMapCamera(camera, Range);
 
-			DrawHostiles(camera, hostiles, 0, 0, width, height, Range);
+			if (_mapCamera == null)
+			{
+				foreach (var cameras in Camera.allCameras)
+				{
+					if (cameras.name == "EFT.Trainer.Features.Map_mapCamera")
+					{
+						_mapCamera = cameras;
+					}
+				}
+			}
+
+			if (_mapCamera == null)
+				return;
+
+			DrawHostiles(_mapCamera, hostiles, Range);
 		}
 
 		protected override void UpdateWhenDisabled()


### PR DESCRIPTION
When drawing the full screen map we use WorldPointToScreenPoint which incorporates the DLSS scaling, for the minimap we use WorldToScreenPoint and subtract the screen height as for some reason this isn't affected by DLSS???. Reordered some variables to prevent having to add a second function within BaseMapToggleFeature. Also streamlined radarSize instead of sizeX and sizeY as we don't need both for a square.

Added in compass function that rotates with map view, some reason it inherits the enemy colors?