### PR TITLE
[Draft] Use GameWorld for finding containers

### DIFF
--- a/Features/LootItems.cs
+++ b/Features/LootItems.cs
@@ -87,22 +87,25 @@ namespace EFT.Trainer.Features
 
 			// Step 2 - look inside containers (items)
 			if (SearchInsideContainers)
-				FindItemsInContainers(records);
+				FindItemsInContainers(world, records);
 
 			return records.ToArray();
 		}
 
-		private void FindItemsInContainers(List<PointOfInterest> records)
+		private void FindItemsInContainers(GameWorld world, List<PointOfInterest> records)
 		{
-			// We have world.ItemOwners, but it seems optimized/lazy-loaded depending on the distance to the player?
-			var containers = FindObjectsOfType<LootableContainer>();
-			foreach (var container in containers)
+			var owners = world.ItemOwners; // contains all containers: corpses, LootContainers, ...
+			foreach (var owner in owners)
 			{
-				if (!container.IsValid())
+				var rootItem = owner.Key.RootItem;
+				if (rootItem is not { IsContainer: true })
 					continue;
 
-				var position = container.transform.position;
-				FindItemsInRootItem(records, container.ItemOwner?.RootItem, position);
+				var parentItem = rootItem.;
+				if (parentItem is Corpse )
+
+				var position = owner.Value.Transform.position;
+				FindItemsInRootItem(records, rootItem, position);
 			}
 		}
 
@@ -123,7 +126,7 @@ namespace EFT.Trainer.Features
 				if (item.IsFiltered())
 					continue;
 
-				TryAddRecordIfTracked(item, records, position, item.Owner?.ContainerName?.Localized());
+				TryAddRecordIfTracked(item, records, position, item.Owner?.RootItem?.TemplateId.LocalizedShortName());
 			}
 		}
 

--- a/Features/LootItems.cs
+++ b/Features/LootItems.cs
@@ -101,8 +101,8 @@ namespace EFT.Trainer.Features
 				if (rootItem is not { IsContainer: true })
 					continue;
 
-				var parentItem = rootItem.;
-				if (parentItem is Corpse )
+				if (rootItem.Parent.Item.IsFiltered())
+					continue;
 
 				var position = owner.Value.Transform.position;
 				FindItemsInRootItem(records, rootItem, position);

--- a/Features/LootableContainers.cs
+++ b/Features/LootableContainers.cs
@@ -36,21 +36,23 @@ namespace EFT.Trainer.Features
 			if (camera == null)
 				return Empty;
 
-			var containers = FindObjectsOfType<LootableContainer>();
+			var owners = world.ItemOwners; 
 			var records = new List<PointOfInterest>();
 
-			foreach (var container in containers)
+			foreach (var owner in owners)
 			{
-				if (!container.IsValid())
+				var itemOwner = owner.Key;
+				var rootItem = itemOwner.RootItem;
+				if (rootItem is not { IsContainer: true })
 					continue;
 
-				if (container.Template != KnownTemplateIds.BuriedBarrelCache && container.Template != KnownTemplateIds.GroundCache)
+				if (rootItem.TemplateId != KnownTemplateIds.BuriedBarrelCache && rootItem.TemplateId != KnownTemplateIds.GroundCache)
 					continue;
 
-				var position = container.transform.position;
+				var position = owner.Value.Transform.position;
 				records.Add(new PointOfInterest
 				{
-					Name = container.Template.LocalizedShortName(),
+					Name = rootItem.TemplateId.LocalizedShortName(), // nicer than ItemOwner.ContainerName which is full caps
 					Position = position,
 					Color = Color
 				});


### PR DESCRIPTION
We are already using cached information in `GameWorld` to find loot, throwables, part of quests, exfils.

But for containers in `stash`, `list` and `loot` features we were still using `FindObjectsOfType` which is super slow.

So use GameWorld.ItemOwners instead, which is a big performance boost.

We still have 5 remaining calls to `FindObjectsOfType`:
- 2x in `Commands`: so not critical but we can reuse the exact same method for `list`
- 2x in `Quests` to find `ExperienceTrigger` and `PlaceItemTrigger`
- 1x in `WallShoot` to find all colliders


