### PR TITLE
Do not save map Enabled state.

### DIFF
--- a/Features/Map.cs
+++ b/Features/Map.cs
@@ -13,6 +13,7 @@ namespace EFT.Trainer.Features
 	{
 		public override string Name => "map";
 
+		[ConfigurationProperty(Skip = true)] // we do not want to offer save/load support for this
 		public override bool Enabled { get; set; } = false;
 
 		[ConfigurationProperty(Order = 20)]


### PR DESCRIPTION
Fixes #346 

We are already doing this for the `Commands` feature, to not store the GUI state, or `GameState`.