### PR TITLE
Add POIs to map overview

### DIFF
--- a/Features/BaseMapToggleFeature.cs
+++ b/Features/BaseMapToggleFeature.cs
@@ -97,8 +97,6 @@ namespace EFT.Trainer.Features
 		{
 			var cameraPosition = camera.transform.position;
 
-			if (MapCamera != null && MapCamera.enabled)
-				cameraPosition.y = 0f;
 
 			var feature = FeatureFactory.GetFeature<Players>();
 			if (feature == null)
@@ -110,6 +108,9 @@ namespace EFT.Trainer.Features
 					continue;
 
 				var position = enemy.Transform.position;
+
+				if (MapCamera != null && MapCamera.enabled)
+					cameraPosition.y = position.y;
 
 				var distance = Vector3.Distance(cameraPosition, position);
 				if (range > 0 && distance > range)

--- a/Features/GameState.cs
+++ b/Features/GameState.cs
@@ -84,6 +84,7 @@ namespace EFT.Trainer.Features
 	public class GameStateSnapshot
 	{
 		public Camera? Camera { get; set; }
+		public Camera? MapCamera { get; set; }
 		public Player? LocalPlayer { get; set; }
 		public IEnumerable<Player> Hostiles { get; set; } = Array.Empty<Player>();
 		public bool MapMode { get; set; } = false;

--- a/Features/Map.cs
+++ b/Features/Map.cs
@@ -44,6 +44,9 @@ namespace EFT.Trainer.Features
 			if (MapCamera == null)
 				return;
 
+			if (snapshot.MapCamera != MapCamera)
+				snapshot.MapCamera = MapCamera;
+
 			Render.DrawPlayer(Render.ScreenCenter, 10f, Color.white, 2f);
 
 			DrawHostiles(MapCamera, hostiles, Range);

--- a/Features/PointOfInterests.cs
+++ b/Features/PointOfInterests.cs
@@ -25,13 +25,11 @@ namespace EFT.Trainer.Features
 			if (snapshot == null)
 				return;
 
-			if (snapshot.MapMode)
-				return;
-
-			var camera = snapshot.Camera;
+			var camera = snapshot.MapMode ? snapshot.MapCamera : snapshot.Camera;
 			if (camera == null)
 				return;
 
+			var cameraPosition = camera.transform.position;
 			var poiPerPosition = data.ToLookup(poi => poi.Position);
 			foreach (var positionGroup in poiPerPosition)
 			{
@@ -40,7 +38,10 @@ namespace EFT.Trainer.Features
 				if (!camera.IsScreenPointVisible(screenPosition))
 					continue;
 
-				var distance = Mathf.Round(Vector3.Distance(camera.transform.position, position));
+				if (snapshot.MapMode)
+					cameraPosition.y = position.y;
+
+				var distance = Mathf.Round(Vector3.Distance(cameraPosition, position));
 				if (MaximumDistance > 0 && distance > MaximumDistance)
 					continue;
 


### PR DESCRIPTION
This adds POIs to map overview by switching between camera and map camera as needed. Additionally included better check for distance when in map view by assigning the camera y position to match the poi y position.