### PR TITLE
TrackWishlist in Loot feature

### DIFF
--- a/Features/Commands.cs
+++ b/Features/Commands.cs
@@ -431,7 +431,6 @@ namespace EFT.Trainer.Features
 				CreateCommand("savetl", $"(?<{ValueGroup}>.+)", m => SaveTrackList(m, liFeature));
 
 				CreateCommand("tracklist", () => ShowTrackList(liFeature));
-				CreateCommand("loadwl", () => LoadWishList(liFeature));
 			}
 
 			CreateCommand("dump", Dump);
@@ -480,20 +479,6 @@ namespace EFT.Trainer.Features
 				var extra = item.Rarity.HasValue ? $" ({item.Rarity.Value.Color()})" : string.Empty;
 				AddConsoleLog(item.Color.HasValue ? $"Tracking: {item.Name.Color(item.Color.Value)}{extra}" : $"Tracking: {item.Name}{extra}");
 			}
-		}
-
-		private static void LoadWishList(LootItems feature)
-		{
-			var player = GameState.Current?.LocalPlayer;
-			if (player == null)
-				return;
-
-			var profile = player.Profile;
-			if (profile == null)
-				return;
-
-			foreach (var itemName in profile.WishList)
-				feature.Track(itemName, null, null);
 		}
 
 		private static bool TryGetTrackListFilename(Match match, [NotNullWhen(true)] out string? filename)

--- a/Features/Commands.cs
+++ b/Features/Commands.cs
@@ -474,6 +474,12 @@ namespace EFT.Trainer.Features
 			if (changed)
 				AddConsoleLog("Tracking list updated...");
 
+			if (feature.Wishlist != null && feature.TrackWishlist)
+				foreach (var wlItem in feature.Wishlist)
+				{
+					AddConsoleLog($"Tracking: {wlItem.Key.LocalizedName()} (Wishlist)");
+				}
+
 			foreach (var item in feature.TrackedNames)
 			{
 				var extra = item.Rarity.HasValue ? $" ({item.Rarity.Value.Color()})" : string.Empty;

--- a/Features/Commands.cs
+++ b/Features/Commands.cs
@@ -474,11 +474,8 @@ namespace EFT.Trainer.Features
 			if (changed)
 				AddConsoleLog("Tracking list updated...");
 
-			if (feature.Wishlist != null && feature.TrackWishlist)
-				foreach (var wlItem in feature.Wishlist)
-				{
-					AddConsoleLog($"Tracking: {wlItem.Key.LocalizedName()} (Wishlist)");
-				}
+			foreach (var templateId in feature.Wishlist)
+				AddConsoleLog($"Tracking: {templateId.LocalizedShortName()} (Wishlist)");
 
 			foreach (var item in feature.TrackedNames)
 			{

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is an attempt -for educational purposes only- to alter a Unity game at runt
 | `Hits`                    | `hits`       | Hit markers (hit, armor, health with configurable colors). |
 | `Hud`                     | `hud`        | HUD (compass, ammo left in chamber / magazine, fire mode, coordinates). |
 | `LootableContainers`      | `stash`      | Hidden stashes like buried barrels or ground caches. |
-| `LootItems`               | `loot`       | List all lootable items and track any item by name or rarity in raid (even in containers and corpses), with prices. |
+| `LootItems`               | `loot`       | List all lootable items and track any item by name or rarity or in-game wishlist in raid (even in containers and corpses), with prices. |
 | `Map`                     | `map`        | Full screen 3D map with radar esp. |
 | `NightVision`             | `night`      | Night vision. |
 | `NoCollision`             | `nocoll`     | No physical collisions, making you immune to bullets, grenades and barbed wires. |
@@ -116,7 +116,6 @@ This trainer hooks into the command system, so you can easily setup features usi
 | listsr     | `[name]` or `*`     |         | List only super rare lootable items |
 | load       |                     |         | Load settings from `trainer.ini`    |
 | loadtl     | `[filename]`        |         | Load current tracklist from file    |
-| loadwl     |                     |         | Load tracklist from your wishlist   |
 | loot       | `on` or `off`       |         | Show/Hide tracked items             |
 | night      | `on` or `off`       | `off`   | Enable/Disable night vision         |
 | nocoll     | `on` or `off`       | `off`   | Disable/Enable physical collisions  |


### PR DESCRIPTION
Removed loadwl command as we have now incorporated it into an option under the Loot feature. If the option is on we assign the Wishlist variable to the wishlist class G2903 or null as appropriate. Then when performing checks in TryAddRecordIfTracked() we shortcut if the item was found in the tracklist or if the Wishlist is null.

Wasn't sure if Wishlist should be private or not. Feel free to change if needed.

Fixes #337 