### PR TITLE
Refactor and optimize

### DIFF
--- a/Extensions/CameraExtensions.cs
+++ b/Extensions/CameraExtensions.cs
@@ -6,7 +6,7 @@ namespace EFT.Trainer.Extensions
 {
 	public static class CameraExtensions
 	{
-		public static Vector3 WorldPointToScreenPoint(this Camera camera, Vector3 worldPoint)
+		public static Vector2 WorldPointToScreenPoint(this Camera camera, Vector3 worldPoint)
 		{
 			var screenPoint = camera.WorldToScreenPoint(worldPoint);
 			var scale = Screen.height / (float)camera.scaledPixelHeight;
@@ -27,11 +27,15 @@ namespace EFT.Trainer.Extensions
 			return hitinfo.transform == transform;
 		}
 
-#pragma warning disable IDE0060 // Remove unused parameter
-		public static bool IsScreenPointVisible(this Camera camera, Vector3 screenPoint)
-#pragma warning restore IDE0060 // Remove unused parameter
+		public static Vector2 WorldPointToVisibleScreenPoint(this Camera camera, Vector3 worldPoint)
 		{
-			return screenPoint is { z: > 0.01f, x: > -5f, y: > -5f } && screenPoint.x < Screen.width && screenPoint.y < Screen.height;
+			var screenPoint = camera.WorldToScreenPoint(worldPoint);
+			var scale = Screen.height / (float)camera.scaledPixelHeight;
+			screenPoint.y = Screen.height - screenPoint.y * scale;
+			screenPoint.x *= scale;
+			if (screenPoint is { z: > 0.01f, x: > -5f, y: > -5f } && screenPoint.x < Screen.width && screenPoint.y < Screen.height)
+				return screenPoint;
+			return Vector2.zero;
 		}
 	}
 }

--- a/Features/Aimbot.cs
+++ b/Features/Aimbot.cs
@@ -157,8 +157,8 @@ namespace EFT.Trainer.Features
 					continue;
 
 				var destination = hostileTransform.position;
-				var screenPosition = camera.WorldPointToScreenPoint(destination);
-				if (!camera.IsScreenPointVisible(screenPosition))
+				var screenPosition = camera.WorldPointToVisibleScreenPoint(destination);
+				if (screenPosition == Vector2.zero)
 					continue;
 
 				if (!IsInFieldOfView(screenPosition))
@@ -198,7 +198,7 @@ namespace EFT.Trainer.Features
 			Render.DrawCircle(Render.ScreenCenter, FovRadius, FovCircleColor, FovCircleThickness, 48);
 		}
 
-		private bool IsInFieldOfView(Vector3 screenPosition)
+		private bool IsInFieldOfView(Vector2 screenPosition)
 		{
 			if (FovRadius <= 0f)
 				return true;

--- a/Features/Bones.cs
+++ b/Features/Bones.cs
@@ -114,7 +114,7 @@ namespace EFT.Trainer.Features
 			foreach (var connection in Connections)
 				RenderBone(bones, connection[0], connection[1], thickness, color, camera, isAiming);
 
-			if (distance < 50f)
+			if (distance < 75f)
 				foreach (var finger in FingerConnections)
 					RenderBone(bones, finger[0], finger[1], thickness, color, camera, isAiming);
 

--- a/Features/PointOfInterests.cs
+++ b/Features/PointOfInterests.cs
@@ -34,8 +34,8 @@ namespace EFT.Trainer.Features
 			foreach (var positionGroup in poiPerPosition)
 			{
 				var position = positionGroup.Key;
-				var screenPosition = camera.WorldPointToScreenPoint(position);
-				if (!camera.IsScreenPointVisible(screenPosition))
+				var screenPosition = camera.WorldPointToVisibleScreenPoint(position);
+				if (screenPosition == Vector2.zero)
 					continue;
 
 				if (snapshot.MapMode)

--- a/UI/Render.cs
+++ b/UI/Render.cs
@@ -68,13 +68,11 @@ namespace EFT.Trainer.UI
 			Color = color;
 
 			var vector = lineEnd - lineStart;
-			float pivot = /* 180/PI */ 57.29578f * Mathf.Atan(vector.y / vector.x);
+			float pivot = /* 180/PI */ Mathf.Rad2Deg * Mathf.Atan(vector.y / vector.x);
 			if (vector.x < 0f)
 				pivot += 180f;
 
-			if (thickness < 1f)
-				thickness = 1;
-
+			thickness = Mathf.Max(thickness, 1f);
 			int yOffset = (int)Mathf.Ceil(thickness / 2);
 
 			GUIUtility.RotateAroundPivot(pivot, lineStart);
@@ -84,45 +82,20 @@ namespace EFT.Trainer.UI
 
 		public static void DrawCircle(Vector2 center, float radius, Color color, float width, int segmentsPerQuarter)
 		{
-			var rh = radius / 2;
+			int totalSegments = segmentsPerQuarter * 4;
+			float step = 1f / totalSegments;
+			var lastV = center + new Vector2(radius, 0);
 
-			var p1 = new Vector2(center.x, center.y - radius);
-			var p1TanA = new Vector2(center.x - rh, center.y - radius);
-			var p1TanB = new Vector2(center.x + rh, center.y - radius);
-
-			var p2 = new Vector2(center.x + radius, center.y);
-			var p2TanA = new Vector2(center.x + radius, center.y - rh);
-			var p2TanB = new Vector2(center.x + radius, center.y + rh);
-
-			var p3 = new Vector2(center.x, center.y + radius);
-			var p3TanA = new Vector2(center.x - rh, center.y + radius);
-			var p3TanB = new Vector2(center.x + rh, center.y + radius);
-
-			var p4 = new Vector2(center.x - radius, center.y);
-			var p4TanA = new Vector2(center.x - radius, center.y - rh);
-			var p4TanB = new Vector2(center.x - radius, center.y + rh);
-
-			DrawBezierLine(p1, p1TanB, p2, p2TanA, color, width, segmentsPerQuarter);
-			DrawBezierLine(p2, p2TanB, p3, p3TanB, color, width, segmentsPerQuarter);
-			DrawBezierLine(p3, p3TanA, p4, p4TanB, color, width, segmentsPerQuarter);
-			DrawBezierLine(p4, p4TanA, p1, p1TanA, color, width, segmentsPerQuarter);
-		}
-
-		public static void DrawBezierLine(Vector2 start, Vector2 startTangent, Vector2 end, Vector2 endTangent, Color color, float width, int segments)
-		{
-			var lastV = CubeBezier(start, startTangent, end, endTangent, 0);
-			for (int i = 1; i < segments + 1; ++i)
+			for (int i = 1; i <= totalSegments; ++i)
 			{
-				var v = CubeBezier(start, startTangent, end, endTangent, i / (float)segments);
-				DrawLine(lastV, v, width, color);
-				lastV = v;
+				float t = i * step;
+				var currentV = center + new Vector2(
+					radius * Mathf.Cos(2 * Mathf.PI * t),
+					radius * Mathf.Sin(2 * Mathf.PI * t)
+				);
+				DrawLine(lastV, currentV, width, color);
+				lastV = currentV;
 			}
-		}
-
-		private static Vector2 CubeBezier(Vector2 s, Vector2 st, Vector2 e, Vector2 et, float t)
-		{
-			float rt = 1 - t;
-			return rt * rt * rt * s + 3 * rt * rt * t * st + 3 * rt * t * t * et + t * t * t * e;
 		}
 	}
 }


### PR DESCRIPTION
Players.cs
Refactored scope w2s function to reduce duplicated code and optimize with Vector2 versus Vector3. Moved Head and Left Shoulder visibility checks up to shortcut if we can't see them either in scope or in the world. Added GetScopeParameters() to get various scope parameters to allow access without repeated fetching from the engine. This could be slightly optimized to only update if the isAiming state changes but I don't think it affects much

CameraExtension.cs
Updated IsScreenPointVisible to WorldPointToVisibleScreenPoint and adjusted checks as necessary to use only Vector2 outside of the initial check. Checks are found in Players, Aimbot, and PointOfInterests features.

Bones.cs
Refactored Bones feature to reduce duplicated code and improve readability. Enable only drawing the fingers on closer targets (75m) as beyond that range they are too small differentiate and the draw calls seem to drag fps down quite a bit.

Render.cs
Applied some optimizations to DrawLine and DrawCircle using Unity variables and optimized some checks for thickness. Rebuilt DrawCircle to single function with easier to read code, circle quality seems unaffected given some testing.