### PR TITLE
Rewrite WallShoot feature

### DIFF
--- a/Features/Ammunition.cs
+++ b/Features/Ammunition.cs
@@ -85,25 +85,4 @@ internal class Ammunition : ToggleFeature
 			harmony.Patch(original, postfix: new HarmonyMethod(postfix));
 		});
 	}
-
-	private class ShotWrapper(object instance) : ReflectionWrapper(instance)
-	{
-		public IPlayer? Player
-		{
-			get
-			{
-				var iface = GetFieldValue<object>(nameof(Player));
-				if (iface == null)
-					return null;
-
-				var property = AccessTools.Property(iface.GetType(), "i" + nameof(Player));
-				if (property == null)
-					return null;
-
-				return property.GetValue(iface) as IPlayer;
-			}
-		} 
-		public Item? Weapon => GetFieldValue<Item>(nameof(Weapon));
-		public Item? Ammo => GetFieldValue<Item>(nameof(Ammo));
-	}
 }

--- a/Model/ShotWrapper.cs
+++ b/Model/ShotWrapper.cs
@@ -1,0 +1,25 @@
+﻿using EFT.InventoryLogic;
+using HarmonyLib;
+
+namespace EFT.Trainer.Model;
+
+internal class ShotWrapper(object instance) : ReflectionWrapper(instance)
+{
+	public IPlayer? Player
+	{
+		get
+		{
+			var iface = GetFieldValue<object>(nameof(Player));
+			if (iface == null)
+				return null;
+
+			var property = AccessTools.Property(iface.GetType(), "i" + nameof(Player));
+			if (property == null)
+				return null;
+
+			return property.GetValue(iface) as IPlayer;
+		}
+	} 
+	public Item? Weapon => GetFieldValue<Item>(nameof(Weapon));
+	public Item? Ammo => GetFieldValue<Item>(nameof(Ammo));
+}

--- a/NLog.EFT.Trainer.csproj
+++ b/NLog.EFT.Trainer.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Features\QuickThrow.cs" />
     <Compile Include="Features\WorldInteractiveObjects.cs" />
     <Compile Include="Model\ReflectionWrapper.cs" />
+    <Compile Include="Model\ShotWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UI\Picker.cs" />
     <Compile Include="UI\EnumPicker.cs" />


### PR DESCRIPTION
Previously `wallshoot` feature was horribly slow, because of the use of `FindObjectsOfType` and `GetComponentsInChildren`. This was even causing FPS drops.

We can achieve the same thing by hooking `BallisticCollider.IsPenetrated`, and converting the feature from `CachableFeature<BallisticCollider[]>` to `ToggleFeature`.

Fixes #368 