### PR TITLE
Spawnbot

### DIFF
--- a/ConsoleCommands/SpawnBot.cs
+++ b/ConsoleCommands/SpawnBot.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Comfort.Common;
-using Diz.Utils;
-using EFT.CameraControl;
 using EFT.Trainer.Extensions;
 using EFT.Trainer.Features;
 using EFT.Trainer.Properties;

--- a/ConsoleCommands/SpawnBot.cs
+++ b/ConsoleCommands/SpawnBot.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Comfort.Common;
+using Diz.Utils;
+using EFT.CameraControl;
+using EFT.Trainer.Extensions;
+using EFT.Trainer.Features;
+using EFT.Trainer.Properties;
+using JetBrains.Annotations;
+
+#nullable enable
+
+namespace EFT.Trainer.ConsoleCommands;
+
+[UsedImplicitly]
+internal class SpawnBot : BaseTemplateCommand
+{
+	public const string MatchAll = "*";
+
+	public override string Name => Strings.CommandSpawnBot;
+
+	public override void Execute(Match match)
+	{
+		var matchGroup = match.Groups[ValueGroup];
+		if (matchGroup is not { Success: true })
+			return;
+
+		var player = GameState.Current?.LocalPlayer;
+		if (player == null)
+			return;
+
+		var search = matchGroup.Value.Trim();
+		var instance = Singleton<IBotGame>.Instance;
+		if (instance == null)
+			return;
+
+		var names = GetBotNames();
+
+		var bots = names
+			.Where(n => n.IndexOf(search, StringComparison.OrdinalIgnoreCase) >= 0)
+			.ToArray();
+
+		if (search == MatchAll)
+		{
+			bots = names;
+		}
+		else
+		{
+			switch (bots.Length)
+			{
+				case 0:
+					AddConsoleLog(Strings.ErrorNoBotFound.Red());
+					return;
+				case > 1:
+					foreach (var name in names)
+						AddConsoleLog(string.Format(Strings.CommandSpawnBotEnumerateFormat, name.Green()));
+
+					AddConsoleLog(string.Format(Strings.ErrorTooManyBotsFormat, bots.Length.ToString().Cyan()));
+					return;
+			}
+		}
+
+		foreach (var bot in bots)
+			instance.BotsController.SpawnBotDebugServer(EPlayerSide.Savage, false, (WildSpawnType)Enum.Parse(typeof(WildSpawnType), bot), BotDifficulty.normal, true);
+	}
+
+	private static string[] GetBotNames()
+	{
+		return Enum
+			.GetNames(typeof(WildSpawnType))
+			.Where(n => n.Contains("boss") || n.Contains("follower"))
+			.Where(n => n.IndexOf("test", StringComparison.OrdinalIgnoreCase) < 0)
+			.Where(n => n.IndexOf("event", StringComparison.OrdinalIgnoreCase) < 0)
+			.OrderBy(n => n)
+			.ToArray();
+	}
+}

--- a/ConsoleCommands/SpawnBot.cs
+++ b/ConsoleCommands/SpawnBot.cs
@@ -51,8 +51,8 @@ internal class SpawnBot : BaseTemplateCommand
 					AddConsoleLog(Strings.ErrorNoBotFound.Red());
 					return;
 				case > 1:
-					foreach (var name in names)
-						AddConsoleLog(string.Format(Strings.CommandSpawnBotEnumerateFormat, name.Green()));
+					foreach (var bot in bots)
+						AddConsoleLog(string.Format(Strings.CommandSpawnBotEnumerateFormat, bot.Green()));
 
 					AddConsoleLog(string.Format(Strings.ErrorTooManyBotsFormat, bots.Length.ToString().Cyan()));
 					return;
@@ -65,11 +65,11 @@ internal class SpawnBot : BaseTemplateCommand
 
 	private static string[] GetBotNames()
 	{
+		var filter = new[] { "test", "event", "spirit", "shooterbtr" };
+
 		return Enum
 			.GetNames(typeof(WildSpawnType))
-			.Where(n => n.Contains("boss") || n.Contains("follower"))
-			.Where(n => n.IndexOf("test", StringComparison.OrdinalIgnoreCase) < 0)
-			.Where(n => n.IndexOf("event", StringComparison.OrdinalIgnoreCase) < 0)
+			.Where(n => !filter.Any(f => n.IndexOf(f, StringComparison.OrdinalIgnoreCase) >= 0))
 			.OrderBy(n => n)
 			.ToArray();
 	}

--- a/NLog.EFT.Trainer.csproj
+++ b/NLog.EFT.Trainer.csproj
@@ -131,6 +131,7 @@
     <Compile Include="ConsoleCommands\ListSuperRare.cs" />
     <Compile Include="ConsoleCommands\LoadTrackList.cs" />
     <Compile Include="ConsoleCommands\SaveTrackList.cs" />
+    <Compile Include="ConsoleCommands\SpawnBot.cs" />
     <Compile Include="ConsoleCommands\Spawn.cs" />
     <Compile Include="ConsoleCommands\Status.cs" />
     <Compile Include="ConsoleCommands\Template.cs" />

--- a/Properties/Strings.Designer.cs
+++ b/Properties/Strings.Designer.cs
@@ -243,6 +243,24 @@ namespace EFT.Trainer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to spawnbot.
+        /// </summary>
+        internal static string CommandSpawnBot {
+            get {
+                return ResourceManager.GetString("CommandSpawnBot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}.
+        /// </summary>
+        internal static string CommandSpawnBotEnumerateFormat {
+            get {
+                return ResourceManager.GetString("CommandSpawnBotEnumerateFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to status.
         /// </summary>
         internal static string CommandStatus {
@@ -594,11 +612,29 @@ namespace EFT.Trainer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No bot found!.
+        /// </summary>
+        internal static string ErrorNoBotFound {
+            get {
+                return ResourceManager.GetString("ErrorNoBotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No template found!.
         /// </summary>
         internal static string ErrorNoTemplateFound {
             get {
                 return ResourceManager.GetString("ErrorNoTemplateFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found {0} bots, be more specific.
+        /// </summary>
+        internal static string ErrorTooManyBotsFormat {
+            get {
+                return ResourceManager.GetString("ErrorTooManyBotsFormat", resourceCulture);
             }
         }
         

--- a/Properties/Strings.fr.resx
+++ b/Properties/Strings.fr.resx
@@ -921,4 +921,17 @@ Les couleurs sont stockées sous la forme d'un tableau de valeurs flottantes 'RG
   <data name="TextSeparator" xml:space="preserve">
     <value>------</value>
   </data>
+  <data name="ErrorNoBotFound" xml:space="preserve">
+    <value>Auncun bot trouvé!</value>
+  </data>
+  <data name="CommandSpawnBot" xml:space="preserve">
+    <value>spawnbot</value>
+  </data>
+  <data name="ErrorTooManyBotsFormat" xml:space="preserve">
+    <value>{0} bots trouvés, essayez d'être plus spécficique</value>
+    <comment>Bot count &gt; 1</comment>
+  </data>
+  <data name="CommandSpawnBotEnumerateFormat" xml:space="preserve">
+    <value>{0}</value>
+  </data>
 </root>

--- a/Properties/Strings.resx
+++ b/Properties/Strings.resx
@@ -921,4 +921,17 @@ Colors are stored as an array of 'RGBA' floats</value>
   <data name="TextSeparator" xml:space="preserve">
     <value>------</value>
   </data>
+  <data name="ErrorNoBotFound" xml:space="preserve">
+    <value>No bot found!</value>
+  </data>
+  <data name="CommandSpawnBot" xml:space="preserve">
+    <value>spawnbot</value>
+  </data>
+  <data name="ErrorTooManyBotsFormat" xml:space="preserve">
+    <value>Found {0} bots, be more specific</value>
+    <comment>Bot count &gt; 1</comment>
+  </data>
+  <data name="CommandSpawnBotEnumerateFormat" xml:space="preserve">
+    <value>{0}</value>
+  </data>
 </root>

--- a/Properties/Strings.zh-cn.resx
+++ b/Properties/Strings.zh-cn.resx
@@ -922,4 +922,17 @@
   <data name="TextSeparator" xml:space="preserve">
     <value>------</value>
   </data>
+  <data name="ErrorNoBotFound" xml:space="preserve">
+    <value>未找到机器人!</value>
+  </data>
+  <data name="CommandSpawnBot" xml:space="preserve">
+    <value>spawnbot</value>
+  </data>
+  <data name="ErrorTooManyBotsFormat" xml:space="preserve">
+    <value>发现{0}个机器人，更具体一点</value>
+    <comment>Bot count &gt; 1</comment>
+  </data>
+  <data name="CommandSpawnBotEnumerateFormat" xml:space="preserve">
+    <value>{0}</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -102,53 +102,54 @@ For newer versions, copy `aki-efttrainer.dll` (this is the compiled code for the
 
 This trainer hooks into the command system, so you can easily setup features using the built-in console:
 
-| Command    | Values              | Default | Description                         |
-|------------|---------------------|---------|-------------------------------------|
-| ammo       | `on` or `off`       | `off`   | Enable/Disable unlimited ammo       |
-| autogun    | `on` or `off`       | `off`   | Enable/Disable automatic gun mode   |
-| crosshair  | `on` or `off`       | `off`   | Show/Hide crosshair                 |
-| dump       |                     |         | Dump game state for analysis        |
-| durability | `on` or `off`       | `off`   | Enable/Disable maximum durability   |
-| examine    | `on` or `off`       | `off`   | Enable/Disable all item examined    |
-| exfil      | `on` or `off`       | `on`    | Show/Hide exfiltration points       |
-| fovchanger | `on` or `off`       | `off`   | Change FOV value                    |
-| ghost      | `on` or `off`       | `off`   | Enable/Disable ghost mode           |
-| grenade    | `on` or `off`       | `off`   | Show/Hide grenades                  |
-| health     | `on` or `off`       | `off`   | Enable/Disable full health          |
-| hits       | `on` or `off`       | `off`   | Show/Hide hit markers               |
-| hud        | `on` or `off`       | `on`    | Show/Hide hud                       |
-| interact   | `on` or `off`       | `off`   | Enable/Disable interaction changes  |
-| list       | `[name]` or `*`     |         | List lootable items                 |
-| listr      | `[name]` or `*`     |         | List only rare lootable items       |
-| listsr     | `[name]` or `*`     |         | List only super rare lootable items |
-| load       |                     |         | Load settings from `trainer.ini`    |
-| loadtl     | `[filename]`        |         | Load current tracklist from file    |
-| loot       | `on` or `off`       |         | Show/Hide tracked items             |
-| night      | `on` or `off`       | `off`   | Enable/Disable night vision         |
-| nocoll     | `on` or `off`       | `off`   | Disable/Enable physical collisions  |
-| nomal      | `on` or `off`       | `off`   | Disable/Enable weapon malfunctions  |
-| norecoil   | `on` or `off`       | `off`   | Disable/Enable recoil               |
-| nosway     | `on` or `off`       | `off`   | Disable/Enable sway                 |
-| novisor    | `on` or `off`       | `off`   | Disable/Enable visor                |
-| quest      | `on` or `off`       | `off`   | Show/Hide quest POI                 |
-| radar      | `on` or `off`       | `off`   | Show/Hide radar                     |
-| save       |                     |         | Save settings to `trainer.ini`      |
-| savetl     | `[filename]`        |         | Save current tracklist to file      |
-| spawn      | `[name]`            |         | Spawn object in front of player     |
-| stamina    | `on` or `off`       | `off`   | Enable/Disable unlimited stamina    |
-| stash      | `on` or `off`       | `off`   | Show/Hide stashes                   |
-| status     |                     |         | Show status of all features         |
-| template   | `[name]`            |         | Search for templates by short/name  |
-| thermal    | `on` or `off`       | `off`   | Enable/Disable thermal vision       |
-| track      | `[name]` or `*`     |         | Track all items matching `name`     |
-| track      | `[name]` `<color>`  |         | Ex: track `roler` `red`             |
-| track      | `[name]` `<rgba>`   |         | Ex: track `roler` `[1,1,1,0.5]`     |
-| trackr     | same as `track`     |         | Track rare items only               |
-| tracksr    | same as `track`     |         | Track super rare items only         |
-| tracklist  |                     |         | Show tracked items                  |
-| untrack    | `[name]` or `*`     |         | Untrack a `name` or `*` for all     |
-| wallhack   | `on` or `off`       | `on`    | Show/hide players                   |
-| wallshoot  | `on` or `off`       | `on`    | Enable/Disable shoot through walls  |
+| Command    | Values              | Default | Description                          |
+|------------|---------------------|---------|--------------------------------------|
+| ammo       | `on` or `off`       | `off`   | Enable/Disable unlimited ammo        |
+| autogun    | `on` or `off`       | `off`   | Enable/Disable automatic gun mode    |
+| crosshair  | `on` or `off`       | `off`   | Show/Hide crosshair                  |
+| dump       |                     |         | Dump game state for analysis         |
+| durability | `on` or `off`       | `off`   | Enable/Disable maximum durability    |
+| examine    | `on` or `off`       | `off`   | Enable/Disable all item examined     |
+| exfil      | `on` or `off`       | `on`    | Show/Hide exfiltration points        |
+| fovchanger | `on` or `off`       | `off`   | Change FOV value                     |
+| ghost      | `on` or `off`       | `off`   | Enable/Disable ghost mode            |
+| grenade    | `on` or `off`       | `off`   | Show/Hide grenades                   |
+| health     | `on` or `off`       | `off`   | Enable/Disable full health           |
+| hits       | `on` or `off`       | `off`   | Show/Hide hit markers                |
+| hud        | `on` or `off`       | `on`    | Show/Hide hud                        |
+| interact   | `on` or `off`       | `off`   | Enable/Disable interaction changes   |
+| list       | `[name]` or `*`     |         | List lootable items                  |
+| listr      | `[name]` or `*`     |         | List only rare lootable items        |
+| listsr     | `[name]` or `*`     |         | List only super rare lootable items  |
+| load       |                     |         | Load settings from `trainer.ini`     |
+| loadtl     | `[filename]`        |         | Load current tracklist from file     |
+| loot       | `on` or `off`       |         | Show/Hide tracked items              |
+| night      | `on` or `off`       | `off`   | Enable/Disable night vision          |
+| nocoll     | `on` or `off`       | `off`   | Disable/Enable physical collisions   |
+| nomal      | `on` or `off`       | `off`   | Disable/Enable weapon malfunctions   |
+| norecoil   | `on` or `off`       | `off`   | Disable/Enable recoil                |
+| nosway     | `on` or `off`       | `off`   | Disable/Enable sway                  |
+| novisor    | `on` or `off`       | `off`   | Disable/Enable visor                 |
+| quest      | `on` or `off`       | `off`   | Show/Hide quest POI                  |
+| radar      | `on` or `off`       | `off`   | Show/Hide radar                      |
+| save       |                     |         | Save settings to `trainer.ini`       |
+| savetl     | `[filename]`        |         | Save current tracklist to file       |
+| spawn      | `[name]`            |         | Spawn object in front of player      |
+| spawnbot   | `[name]` or `*`     |         | Spawn a bot, ex `spawnbot bossKilla` |
+| stamina    | `on` or `off`       | `off`   | Enable/Disable unlimited stamina     |
+| stash      | `on` or `off`       | `off`   | Show/Hide stashes                    |
+| status     |                     |         | Show status of all features          |
+| template   | `[name]`            |         | Search for templates by short/name   |
+| thermal    | `on` or `off`       | `off`   | Enable/Disable thermal vision        |
+| track      | `[name]` or `*`     |         | Track all items matching `name`      |
+| track      | `[name]` `<color>`  |         | Ex: track `roler` `red`              |
+| track      | `[name]` `<rgba>`   |         | Ex: track `roler` `[1,1,1,0.5]`      |
+| trackr     | same as `track`     |         | Track rare items only                |
+| tracksr    | same as `track`     |         | Track super rare items only          |
+| tracklist  |                     |         | Show tracked items                   |
+| untrack    | `[name]` or `*`     |         | Untrack a `name` or `*` for all      |
+| wallhack   | `on` or `off`       | `on`    | Show/hide players                    |
+| wallshoot  | `on` or `off`       | `on`    | Enable/Disable shoot through walls   |
 
 ## Translations
 


### PR DESCRIPTION
Add a new command to spawn bots in the map.

Examples:

`spawnbot bossKilla`
`spawnbot gifter`
`spawnbot *`

Argument is a member of the following filtered `WildSpawnType` enumeration (or `*` to spawn them all):
```
arenaFighter
assault
assaultGroup
bossBoar
bossBoarSniper
bossBully
bossGluhar 
bossKilla
bossKnight
bossKojaniy
bossKolontay
bossSanitar
bossTagilla
bossZryachiy
cursedAssault 
exUsec
followerBigPipe
followerBirdEye
followerBoar
followerBoarClose1
followerBoarClose2
followerBully
followerGluharAssault 
followerGluharScout
followerGluharSecurity 
followerGluharSniper
followerKojaniy
followerKolontayAssault
followerKolontaySecurity
followerSanitar
followerTagilla
followerZryachiy
gifter
marksman
peacemaker
pmcBEAR
pmcBot
pmcUSEC
sectantPriest
sectantWarrior
skier
```