### PR TITLE
Refine installer

### DIFF
--- a/Features/Examine.cs
+++ b/Features/Examine.cs
@@ -26,6 +26,7 @@ internal class Examine : ToggleFeature
 		return false; // skip the original code and all other prefix methods 
 	}
 
+#pragma warning disable IDE0060
 	[UsedImplicitly]
 	protected static bool SinglePlayerInventoryControllerConstructorPrefix(Player player, Profile profile, ref bool examined)
 	{
@@ -37,6 +38,7 @@ internal class Examine : ToggleFeature
 		examined = true;
 		return true;
 	}
+#pragma warning restore IDE0060
 
 	protected override void UpdateWhenEnabled()
 	{

--- a/Installer/InstallCommand.cs
+++ b/Installer/InstallCommand.cs
@@ -66,6 +66,19 @@ internal sealed class InstallCommand : AsyncCommand<InstallCommand.Settings>
 
 			AnsiConsole.MarkupLine($"Target [green]EscapeFromTarkov ({installation.Version})[/] in [blue]{installation.Location.EscapeMarkup()}[/].");
 
+			if (installation.UsingSptAki)
+			{
+				AnsiConsole.MarkupLine("[green][[SPT-AKI]][/] detected. Please make sure you have run the game at least once before installing the trainer.");
+				AnsiConsole.MarkupLine("SPT-AKI is patching binaries during the first run, and we [underline]need[/] to compile against those patched binaries.");
+				AnsiConsole.MarkupLine("If you install this trainer on stock binaries, we'll be unable to compile or the game will freeze at the startup screen.");
+
+				if (installation.UsingSptAkiButNeverRun)
+					AnsiConsole.MarkupLine("[yellow]Warning: it seems that you have never run your SPT-AKI installation. You should quit now and rerun this installer once it's done.[/]");
+
+				if (!AnsiConsole.Confirm("Continue installation (yes I have run the game at least once) ?"))
+					return (int)ExitCode.Canceled;
+			}
+
 			const string features = "Features";
 			const string commands = "ConsoleCommands";
 
@@ -79,16 +92,6 @@ internal sealed class InstallCommand : AsyncCommand<InstallCommand.Settings>
 				// Failure
 				AnsiConsole.MarkupLine($"[red]Unable to compile trainer for version {installation.Version}. Please file an issue here : https://github.com/sailro/EscapeFromTarkov-Trainer/issues [/]");
 				return (int)ExitCode.CompilationFailed;
-			}
-
-			if (installation.UsingSptAki)
-			{
-				AnsiConsole.MarkupLine("[green][[SPT-AKI]][/] detected. Please make sure you have run the game at least once before installing the trainer.");
-				AnsiConsole.MarkupLine("SPT-AKI is patching binaries during the first run, and we [underline]need[/] to compile against those patched binaries.");
-				AnsiConsole.MarkupLine("If you install this trainer on stock binaries, the game will freeze at the startup screen.");
-
-				if (!AnsiConsole.Confirm("Continue installation (yes I have run the game at least once) ?"))
-					return (int)ExitCode.Canceled;
 			}
 
 			if (!CreateDll(installation, "NLog.EFT.Trainer.dll", dllPath => result.Compilation.Emit(dllPath, manifestResources: result.Resources)))

--- a/Installer/Installation.cs
+++ b/Installer/Installation.cs
@@ -18,6 +18,8 @@ internal class Installation
 	public bool UsingSptAkiButNeverRun { get; private set; }
 	public bool UsingBepInEx { get; private set; }
 	public string Location { get; }
+	public string DisplayString { get; private set; } = string.Empty;
+
 	public string Data => Path.Combine(Location, "EscapeFromTarkov_Data");
 	public string Managed => Path.Combine(Data, "Managed");
 	public string BepInEx => Path.Combine(Location, "BepInEx");
@@ -58,10 +60,10 @@ internal class Installation
 				installations = DiscoverInstallations()
 					.Distinct()
 					.ToList();
-			});
 
-		if (path is not null && TryDiscoverInstallation(path, out var installation))
-			installations.Add(installation);
+				if (path is not null && TryDiscoverInstallation(path, out var installation))
+					installations.Add(installation);
+			});
 
 		installations = [.. installations.Distinct().OrderBy(i => i.Location)];
 
@@ -152,6 +154,8 @@ internal class Installation
 
 			installation.UsingBepInEx = Directory.Exists(installation.BepInExPlugins);
 
+			installation.DisplayString = installation.ComputeDisplayString();
+
 			return true;
 		}
 		catch (IOException)
@@ -160,15 +164,20 @@ internal class Installation
 		}
 	}
 
-	public override string ToString()
+	private string ComputeDisplayString()
 	{
 		var sb = new StringBuilder();
 		sb.Append($"{Location.EscapeMarkup()} - [[{Version}]] ");
 		sb.Append(UsingSptAki ? "[b]SPT-AKI[/] " : "Vanilla ");
 
-		if (VersionChecker.IsVersionSupported(Version) && UsingSptAki)
+		if (UsingSptAki && VersionChecker.IsVersionSupported(Version))
 			sb.Append("[green](Supported)[/]");
 
 		return sb.ToString();
+	}
+
+	public override string ToString()
+	{
+		return DisplayString;
 	}
 }

--- a/Installer/Installation.cs
+++ b/Installer/Installation.cs
@@ -164,7 +164,11 @@ internal class Installation
 	{
 		var sb = new StringBuilder();
 		sb.Append($"{Location.EscapeMarkup()} - [[{Version}]] ");
-		sb.Append(UsingSptAki ? "[b]SPT-AKI[/]" : "Vanilla");
+		sb.Append(UsingSptAki ? "[b]SPT-AKI[/] " : "Vanilla ");
+
+		if (VersionChecker.IsVersionSupported(Version) && UsingSptAki)
+			sb.Append("[green](Supported)[/]");
+
 		return sb.ToString();
 	}
 }

--- a/Installer/Installation.cs
+++ b/Installer/Installation.cs
@@ -14,6 +14,7 @@ internal class Installation
 {
 	public Version Version { get; }
 	public bool UsingSptAki { get; private set; }
+	public bool UsingSptAkiButNeverRun { get; private set; }
 	public bool UsingBepInEx { get; private set; }
 	public string Location { get; }
 	public string Data => Path.Combine(Location, "EscapeFromTarkov_Data");
@@ -91,6 +92,10 @@ internal class Installation
 		if (TryDiscoverInstallation(Path.GetDirectoryName(AppContext.BaseDirectory), out installation))
 			yield return installation;
 
+		// SPT-AKI default installation path
+		if (TryDiscoverInstallation(Path.Combine(Path.GetPathRoot(Environment.GetFolderPath(Environment.SpecialFolder.System))!, "SPT"), out installation))
+			yield return installation;
+
 		using var hive = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
 		using var eft = hive.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall\EscapeFromTarkov", false);
 
@@ -142,6 +147,11 @@ internal class Installation
 			var legacyAkiFolder = Path.Combine(path, "Aki_Data");
 			var akiFolder = Path.Combine(path, "SPT_Data");
 			installation.UsingSptAki = Directory.Exists(akiFolder) || Directory.Exists(legacyAkiFolder);
+
+
+			var battleye = Path.Combine(path, "BattlEye");
+			var user = Path.Combine(path, "user");
+			installation.UsingSptAkiButNeverRun = installation.UsingSptAki && (Directory.Exists(battleye) || !Directory.Exists(user));
 
 			installation.UsingBepInEx = Directory.Exists(installation.BepInExPlugins);
 

--- a/Installer/Installation.cs
+++ b/Installer/Installation.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
+using System.Text;
 using Microsoft.Win32;
 using Spectre.Console;
 
@@ -73,11 +74,7 @@ internal class Installation
 				var first = installations.First();
 				return AnsiConsole.Confirm($"Continue with [green]EscapeFromTarkov ({first.Version})[/] in [blue]{first.Location.EscapeMarkup()}[/] ?") ? first : null;
 			default:
-				var prompt = new SelectionPrompt<Installation>
-				{
-					Converter = i => i.Location.EscapeMarkup(),
-					Title = promptTitle
-				};
+				var prompt = new SelectionPrompt<Installation> { Title = promptTitle };
 				prompt.AddChoices(installations);
 				return AnsiConsole.Prompt(prompt);
 		}
@@ -161,5 +158,13 @@ internal class Installation
 		{
 			return false;
 		}
+	}
+
+	public override string ToString()
+	{
+		var sb = new StringBuilder();
+		sb.Append($"{Location.EscapeMarkup()} - [[{Version}]] ");
+		sb.Append(UsingSptAki ? "[b]SPT-AKI[/]" : "Vanilla");
+		return sb.ToString();
 	}
 }

--- a/Installer/Installer.csproj
+++ b/Installer/Installer.csproj
@@ -17,7 +17,7 @@
 
     <Authors>Sebastien Lebreton</Authors>
     <RepositoryUrl>https://github.com/sailro/EscapeFromTarkov-Trainer</RepositoryUrl>
-    <Version>3.0.0.0</Version>
+    <Version>3.1.0.0</Version>
     <Copyright>Sebastien Lebreton</Copyright>
   </PropertyGroup>
 

--- a/Installer/VersionChecker.cs
+++ b/Installer/VersionChecker.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Spectre.Console;
+
+namespace Installer;
+
+internal class VersionChecker
+{
+
+	private static readonly Dictionary<Version, bool> _versions = [];
+
+	public static async Task<bool> IsVersionSupportedAsync(Version version)
+	{
+		if (_versions.TryGetValue(version, out var supported))
+			return supported;
+
+		try
+		{
+			var branch = $"dev-{version}";
+			using var client = new HttpClient();
+			var result = await client.GetAsync(new Uri($"https://github.com/sailro/EscapeFromTarkov-Trainer/archive/refs/heads/{branch}.zip"));
+			_versions[version] = result.IsSuccessStatusCode;
+			return _versions[version];
+		}
+		catch (Exception e)
+		{
+#if DEBUG
+			AnsiConsole.WriteException(e);
+#endif
+
+			return false;
+		}
+	}
+
+	public static bool IsVersionSupported(Version version)
+	{
+#pragma warning disable VSTHRD002
+		return IsVersionSupportedAsync(version)
+			.GetAwaiter()
+			.GetResult();
+#pragma warning restore VSTHRD002
+	}
+}

--- a/Installer/VersionChecker.cs
+++ b/Installer/VersionChecker.cs
@@ -10,6 +10,7 @@ internal class VersionChecker
 {
 
 	private static readonly Dictionary<Version, bool> _versions = [];
+	private static readonly HttpClient _client = new();
 
 	public static async Task<bool> IsVersionSupportedAsync(Version version)
 	{
@@ -19,8 +20,8 @@ internal class VersionChecker
 		try
 		{
 			var branch = $"dev-{version}";
-			using var client = new HttpClient();
-			var result = await client.GetAsync(new Uri($"https://github.com/sailro/EscapeFromTarkov-Trainer/archive/refs/heads/{branch}.zip"));
+			var uri = new Uri($"https://github.com/sailro/EscapeFromTarkov-Trainer/tree/{branch}");
+			var result = await _client.GetAsync(uri);
 			_versions[version] = result.IsSuccessStatusCode;
 			return _versions[version];
 		}


### PR DESCRIPTION
- detect SPT-AKI and display the prompt even before trying to compile (because we will probably fail)
- add `C:\SPT` to the well-known list of installations (SPT-AKI default installation path)
- detect when SPT-AKI was never run, and add another warning given it seems hard to understand :)