### PR TITLE
Add extra setup for spawned items

### DIFF
--- a/ConsoleCommands/Spawn.cs
+++ b/ConsoleCommands/Spawn.cs
@@ -10,7 +10,6 @@ using EFT.Trainer.Extensions;
 using EFT.Trainer.Features;
 using EFT.Trainer.Properties;
 using JetBrains.Annotations;
-using UnityEngine;
 using Random = UnityEngine.Random;
 
 #nullable enable
@@ -87,7 +86,7 @@ internal class Spawn : BaseTemplateCommand
 						}
 						else
 						{
-							item.SpawnedInSession = true; // found in raid
+							SetupItem(itemFactory, item);
 
 							_ = new TraderControllerClass(item, item.Id, item.ShortName);
 							var go = poolManager.CreateLootPrefab(item, ECameraType.Default);
@@ -109,5 +108,40 @@ internal class Spawn : BaseTemplateCommand
 
 				return Task.CompletedTask;
 			});
+	}
+
+	private static void SetupItem(ItemFactoryClass itemFactory, Item item)
+	{
+		item.SpawnedInSession = true; // found in raid
+
+		if (item.TryGetItemComponent<DogtagComponent>(out var dogtag))
+		{
+			dogtag.AccountId = Random.Range(0, int.MaxValue).ToString();
+			dogtag.ProfileId = Random.Range(0, int.MaxValue).ToString();
+			dogtag.Nickname = $"Rambo{Random.Range(1, 256)}";
+			dogtag.Side = Enum.GetValues(typeof(EPlayerSide)).Cast<EPlayerSide>().Random();
+			dogtag.Level = Random.Range(1, 69);
+			dogtag.Time = DateTime.Now;
+			dogtag.Status = "died";
+			dogtag.KillerAccountId = Random.Range(0, int.MaxValue).ToString();
+			dogtag.KillerProfileId = Random.Range(0, int.MaxValue).ToString();
+			dogtag.KillerName = "";
+			dogtag.WeaponName = "";
+		}
+
+		if (item.TryGetItemComponent<ArmorHolderComponent>(out var armorHolder))
+		{
+			foreach (var slot in armorHolder.ArmorSlots)
+			{
+				var plate = itemFactory.CreateItem(MongoID.Generate(), KnownTemplateIds.CultTermiteBallisticPlate, null);
+				slot.AddWithoutRestrictions(plate);
+			}
+		}
+
+		if (item.TryGetItemComponent<RepairableComponent>(out var repairable))
+		{
+			repairable.MaxDurability = repairable.TemplateDurability;
+			repairable.Durability = repairable.MaxDurability;
+		}
 	}
 }

--- a/KnownTemplateIds.cs
+++ b/KnownTemplateIds.cs
@@ -18,5 +18,7 @@ public static class KnownTemplateIds
 	public const string AirDropSupply = "622334fa3136504a544d160c";
 	public const string AirDropWeapon = "6223351bb5d97a7b2c635ca7";
 
+	public const string CultTermiteBallisticPlate = "656fa99800d62bcd2e024088";
+
 	public static string DefaultInventoryLocalizedShortName = ((MongoID)DefaultInventory).LocalizedShortName();
 }


### PR DESCRIPTION
Items like armors or dogtags need extra setup to work properly.

So added a new method `SetupItem` to handle this.

Given we blindly add armor plates to all possible slots we are creating impossible combinations of armor, but it seems to be working properly:

![2024-09-25 20-41 _19 4, -1 4, -13 8_-0 4, 0 5, -0 3, -0 7 (0)](https://github.com/user-attachments/assets/8e1e4d34-0933-4ec8-b1a7-61357d858d43)

![2024-09-25 20-31 _15 2, 6 1, 38 9_0 0, 0 0, 0 0, 1 0 (1)](https://github.com/user-attachments/assets/42bf7514-1424-4a6e-938d-b31f7b92ab48)



