### PR TITLE
Improve spawn command

### DIFF
--- a/KnownTemplateIds.cs
+++ b/KnownTemplateIds.cs
@@ -18,7 +18,5 @@ public static class KnownTemplateIds
 	public const string AirDropSupply = "622334fa3136504a544d160c";
 	public const string AirDropWeapon = "6223351bb5d97a7b2c635ca7";
 
-	public const string CultTermiteBallisticPlate = "656fa99800d62bcd2e024088";
-
 	public static string DefaultInventoryLocalizedShortName = ((MongoID)DefaultInventory).LocalizedShortName();
 }


### PR DESCRIPTION
Improve `spawn` command:

- spawn complete armors with proper specs (instead of using hardcoded plates)
- spawn complete weapons 

Examples with `spawn "colt m4a1"`:

![2024-09-29 16-20 _68 3, 1 5, -48 4_0 0, 0 8, 0 0, 0 6 (0)](https://github.com/user-attachments/assets/128d8763-4ce6-4a35-a9df-7522237f3c3f)
![2024-09-29 17-00 _7 0, 1 6, -7 5_0 0, 1 0, 0 0, 0 2 (0)](https://github.com/user-attachments/assets/4597de55-05e6-465a-8df8-feddf430bda6)
![2024-09-29 17-00 _7 0, 1 6, -7 5_0 0, 1 0, 0 0, 0 2 (2)](https://github.com/user-attachments/assets/ee8a4570-e6ce-4007-b384-735ab7a4bff4)
![2024-09-29 17-01 _7 0, 1 6, -7 5_0 0, 1 0, 0 0, 0 2 (0)](https://github.com/user-attachments/assets/2f60bed5-25f8-4edb-abb0-21b7940657ec)
![2024-09-29 17-01 _7 0, 1 6, -7 5_0 0, 1 0, 0 0, 0 2 (1)](https://github.com/user-attachments/assets/d5a212e5-db19-46c3-b988-8fbd7af6674f)


